### PR TITLE
Implement command for adding meeting entry

### DIFF
--- a/src/main/java/seedu/address/logic/commands/meetingentry/AddCommand.java
+++ b/src/main/java/seedu/address/logic/commands/meetingentry/AddCommand.java
@@ -15,7 +15,7 @@ import seedu.address.model.Model;
 import seedu.address.model.meetingentry.MeetingEntry;
 
 /**
- * Adds a MeetingEntry to LinkyTime.
+ * Adds a meeting entry to LinkyTime.
  */
 public class AddCommand extends Command {
 
@@ -38,7 +38,7 @@ public class AddCommand extends Command {
             + PREFIX_TAG + "Boring";
 
     public static final String MESSAGE_SUCCESS = "New meeting entry added: %1$s";
-    public static final String MESSAGE_DUPLICATE_PERSON = "This meeting entry already exists in LinkyTime";
+    public static final String MESSAGE_DUPLICATE_ENTRY = "This meeting entry already exists in LinkyTime";
 
     private final MeetingEntry toAdd;
 
@@ -55,7 +55,7 @@ public class AddCommand extends Command {
         requireNonNull(model);
 
         if (model.hasMeetingEntry(toAdd)) {
-            throw new CommandException(MESSAGE_DUPLICATE_PERSON);
+            throw new CommandException(MESSAGE_DUPLICATE_ENTRY);
         }
 
         model.addMeetingEntry(toAdd);

--- a/src/main/java/seedu/address/logic/commands/meetingentry/AddCommand.java
+++ b/src/main/java/seedu/address/logic/commands/meetingentry/AddCommand.java
@@ -1,4 +1,71 @@
 package seedu.address.logic.commands.meetingentry;
 
-public class AddCommand {
+import static java.util.Objects.requireNonNull;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_DATETIME;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_MODULE_CODE;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_RECURRING;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_URL;
+
+import seedu.address.logic.commands.Command;
+import seedu.address.logic.commands.CommandResult;
+import seedu.address.logic.commands.exceptions.CommandException;
+import seedu.address.model.Model;
+import seedu.address.model.meetingentry.MeetingEntry;
+
+/**
+ * Adds a MeetingEntry to LinkyTime.
+ */
+public class AddCommand extends Command {
+
+    public static final String COMMAND_WORD = "add";
+
+    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Adds a meeting entry to LinkyTime. "
+            + "Parameters: "
+            + PREFIX_NAME + "MEETING_NAME "
+            + PREFIX_URL + "LINK "
+            + PREFIX_DATETIME + "DATETIME "
+            + PREFIX_MODULE_CODE + "MODULE CODE "
+            + PREFIX_RECURRING + "IS RECURRING "
+            + "[" + PREFIX_TAG + "TAG]...\n"
+            + "Example: " + COMMAND_WORD + " "
+            + PREFIX_NAME + "Tutorial "
+            + PREFIX_URL + "www.zoom.com "
+            + PREFIX_DATETIME + "13mar2022 "
+            + PREFIX_MODULE_CODE + "CS2103 "
+            + PREFIX_RECURRING + "Yes "
+            + PREFIX_TAG + "Boring";
+
+    public static final String MESSAGE_SUCCESS = "New meeting entry added: %1$s";
+    public static final String MESSAGE_DUPLICATE_PERSON = "This meeting entry already exists in LinkyTime";
+
+    private final MeetingEntry toAdd;
+
+    /**
+     * Creates an AddCommand to add the specified {@code MeetingEntry}
+     */
+    public AddCommand(MeetingEntry entry) {
+        requireNonNull(entry);
+        toAdd = entry;
+    }
+
+    @Override
+    public CommandResult execute(Model model) throws CommandException {
+        requireNonNull(model);
+
+        if (model.hasMeetingEntry(toAdd)) {
+            throw new CommandException(MESSAGE_DUPLICATE_PERSON);
+        }
+
+        model.addMeetingEntry(toAdd);
+        return new CommandResult(String.format(MESSAGE_SUCCESS, toAdd));
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        return other == this // short circuit if same object
+                || (other instanceof AddCommand // instanceof handles nulls
+                && toAdd.equals(((AddCommand) other).toAdd));
+    }
 }

--- a/src/main/java/seedu/address/logic/commands/meetingentry/AddCommand.java
+++ b/src/main/java/seedu/address/logic/commands/meetingentry/AddCommand.java
@@ -18,9 +18,7 @@ import seedu.address.model.meetingentry.MeetingEntry;
  * Adds a meeting entry to LinkyTime.
  */
 public class AddCommand extends Command {
-
     public static final String COMMAND_WORD = "add";
-
     public static final String MESSAGE_USAGE = COMMAND_WORD + ": Adds a meeting entry to LinkyTime. "
             + "Parameters: "
             + PREFIX_NAME + "MEETING_NAME "
@@ -38,7 +36,7 @@ public class AddCommand extends Command {
             + PREFIX_TAG + "Boring";
 
     public static final String MESSAGE_SUCCESS = "New meeting entry added: %1$s";
-    public static final String MESSAGE_DUPLICATE_ENTRY = "This meeting entry already exists in LinkyTime";
+    public static final String MESSAGE_DUPLICATE_MEETING_ENTRY = "This meeting entry already exists in LinkyTime";
 
     private final MeetingEntry toAdd;
 
@@ -55,7 +53,7 @@ public class AddCommand extends Command {
         requireNonNull(model);
 
         if (model.hasMeetingEntry(toAdd)) {
-            throw new CommandException(MESSAGE_DUPLICATE_ENTRY);
+            throw new CommandException(MESSAGE_DUPLICATE_MEETING_ENTRY);
         }
 
         model.addMeetingEntry(toAdd);

--- a/src/main/java/seedu/address/logic/parser/LinkyTimeParser.java
+++ b/src/main/java/seedu/address/logic/parser/LinkyTimeParser.java
@@ -9,7 +9,9 @@ import java.util.regex.Pattern;
 import seedu.address.logic.commands.Command;
 import seedu.address.logic.commands.ExitCommand;
 import seedu.address.logic.commands.HelpCommand;
+import seedu.address.logic.commands.meetingentry.AddCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
+import seedu.address.logic.parser.meetingentry.AddCommandParser;
 
 /**
  * Parses user input.
@@ -38,6 +40,8 @@ public class LinkyTimeParser {
         final String arguments = matcher.group("arguments");
 
         switch (commandWord) {
+        case AddCommand.COMMAND_WORD:
+            return new AddCommandParser().parse(arguments);
         case ExitCommand.COMMAND_WORD:
             return new ExitCommand();
         default:

--- a/src/main/java/seedu/address/logic/parser/meetingentry/AddCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/meetingentry/AddCommandParser.java
@@ -1,4 +1,69 @@
 package seedu.address.logic.parser.meetingentry;
 
-public class AddCommandParser {
+import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_DATETIME;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_MODULE_CODE;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_RECURRING;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_URL;
+
+import java.util.Set;
+import java.util.stream.Stream;
+
+import seedu.address.logic.commands.meetingentry.AddCommand;
+import seedu.address.logic.parser.ArgumentMultimap;
+import seedu.address.logic.parser.ArgumentTokenizer;
+import seedu.address.logic.parser.Parser;
+import seedu.address.logic.parser.ParserUtil;
+import seedu.address.logic.parser.Prefix;
+import seedu.address.logic.parser.exceptions.ParseException;
+import seedu.address.model.meetingentry.IsRecurring;
+import seedu.address.model.meetingentry.MeetingDateTime;
+import seedu.address.model.meetingentry.MeetingEntry;
+import seedu.address.model.meetingentry.MeetingName;
+import seedu.address.model.meetingentry.MeetingUrl;
+import seedu.address.model.modulecode.ModuleCode;
+import seedu.address.model.tag.Tag;
+
+/**
+ * Parses input arguments and creates a new AddCommand object
+ */
+public class AddCommandParser implements Parser<AddCommand> {
+
+    /**
+     * Parses the given {@code String} of arguments in the context of the AddCommand
+     * and returns an AddCommand object for execution.
+     * @throws ParseException if the user input does not conform the expected format
+     */
+    public AddCommand parse(String args) throws ParseException {
+        ArgumentMultimap argMultimap =
+                ArgumentTokenizer.tokenize(args, PREFIX_NAME, PREFIX_URL, PREFIX_DATETIME,
+                        PREFIX_MODULE_CODE, PREFIX_RECURRING, PREFIX_TAG);
+
+        if (!arePrefixesPresent(argMultimap, PREFIX_NAME, PREFIX_URL, PREFIX_DATETIME,
+                PREFIX_MODULE_CODE, PREFIX_RECURRING)
+                || !argMultimap.getPreamble().isEmpty()) {
+            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, AddCommand.MESSAGE_USAGE));
+        }
+
+        MeetingName name = ParserUtil.parseMeetingName(argMultimap.getValue(PREFIX_NAME).get());
+        MeetingUrl url = ParserUtil.parseMeetingUrl(argMultimap.getValue(PREFIX_URL).get());
+        MeetingDateTime dateTime = ParserUtil.parseMeetingDateTime(argMultimap.getValue(PREFIX_DATETIME).get());
+        ModuleCode moduleCode = ParserUtil.parseModuleCode(argMultimap.getValue(PREFIX_MODULE_CODE).get());
+        IsRecurring recurringStatus = ParserUtil.parseRecurringStatus(argMultimap.getValue(PREFIX_RECURRING).get());
+        Set<Tag> tagList = ParserUtil.parseTags(argMultimap.getAllValues(PREFIX_TAG));
+
+        MeetingEntry meetingEntry = new MeetingEntry(name, url, dateTime, moduleCode, recurringStatus, tagList);
+
+        return new AddCommand(meetingEntry);
+    }
+
+    /**
+     * Returns true if none of the prefixes contains empty {@code Optional} values in the given
+     * {@code ArgumentMultimap}.
+     */
+    private static boolean arePrefixesPresent(ArgumentMultimap argumentMultimap, Prefix... prefixes) {
+        return Stream.of(prefixes).allMatch(prefix -> argumentMultimap.getValue(prefix).isPresent());
+    }
 }

--- a/src/main/java/seedu/address/logic/parser/meetingentry/AddCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/meetingentry/AddCommandParser.java
@@ -34,10 +34,11 @@ public class AddCommandParser implements Parser<AddCommand> {
     /**
      * Parses the given {@code String} of arguments in the context of the AddCommand
      * and returns an AddCommand object for execution.
+     *
      * @throws ParseException if the user input does not conform the expected format
      */
     public AddCommand parse(String args) throws ParseException {
-        ArgumentMultimap argMultimap =
+        final ArgumentMultimap argMultimap =
                 ArgumentTokenizer.tokenize(args, PREFIX_NAME, PREFIX_URL, PREFIX_DATETIME,
                         PREFIX_MODULE_CODE, PREFIX_RECURRING, PREFIX_TAG);
 
@@ -47,14 +48,14 @@ public class AddCommandParser implements Parser<AddCommand> {
             throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, AddCommand.MESSAGE_USAGE));
         }
 
-        MeetingName name = ParserUtil.parseMeetingName(argMultimap.getValue(PREFIX_NAME).get());
-        MeetingUrl url = ParserUtil.parseMeetingUrl(argMultimap.getValue(PREFIX_URL).get());
-        MeetingDateTime dateTime = ParserUtil.parseMeetingDateTime(argMultimap.getValue(PREFIX_DATETIME).get());
-        ModuleCode moduleCode = ParserUtil.parseModuleCode(argMultimap.getValue(PREFIX_MODULE_CODE).get());
-        IsRecurring recurringStatus = ParserUtil.parseRecurringStatus(argMultimap.getValue(PREFIX_RECURRING).get());
-        Set<Tag> tagList = ParserUtil.parseTags(argMultimap.getAllValues(PREFIX_TAG));
+        final MeetingName name = ParserUtil.parseMeetingName(argMultimap.getValue(PREFIX_NAME).get());
+        final MeetingUrl url = ParserUtil.parseMeetingUrl(argMultimap.getValue(PREFIX_URL).get());
+        final MeetingDateTime dateTime = ParserUtil.parseMeetingDateTime(argMultimap.getValue(PREFIX_DATETIME).get());
+        final ModuleCode moduleCode = ParserUtil.parseModuleCode(argMultimap.getValue(PREFIX_MODULE_CODE).get());
+        final IsRecurring recurringStatus = ParserUtil.parseRecurringStatus(argMultimap.getValue(PREFIX_RECURRING).get());
+        final Set<Tag> tagList = ParserUtil.parseTags(argMultimap.getAllValues(PREFIX_TAG));
 
-        MeetingEntry meetingEntry = new MeetingEntry(name, url, dateTime, moduleCode, recurringStatus, tagList);
+        final MeetingEntry meetingEntry = new MeetingEntry(name, url, dateTime, moduleCode, recurringStatus, tagList);
 
         return new AddCommand(meetingEntry);
     }

--- a/src/main/java/seedu/address/logic/parser/meetingentry/AddCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/meetingentry/AddCommandParser.java
@@ -30,7 +30,6 @@ import seedu.address.model.tag.Tag;
  * Parses input arguments and creates a new AddCommand object
  */
 public class AddCommandParser implements Parser<AddCommand> {
-
     /**
      * Parses the given {@code String} of arguments in the context of the AddCommand
      * and returns an AddCommand object for execution.

--- a/src/main/java/seedu/address/logic/parser/meetingentry/AddCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/meetingentry/AddCommandParser.java
@@ -52,7 +52,8 @@ public class AddCommandParser implements Parser<AddCommand> {
         final MeetingUrl url = ParserUtil.parseMeetingUrl(argMultimap.getValue(PREFIX_URL).get());
         final MeetingDateTime dateTime = ParserUtil.parseMeetingDateTime(argMultimap.getValue(PREFIX_DATETIME).get());
         final ModuleCode moduleCode = ParserUtil.parseModuleCode(argMultimap.getValue(PREFIX_MODULE_CODE).get());
-        final IsRecurring recurringStatus = ParserUtil.parseRecurringStatus(argMultimap.getValue(PREFIX_RECURRING).get());
+        final IsRecurring recurringStatus = ParserUtil.parseRecurringStatus(argMultimap
+                .getValue(PREFIX_RECURRING).get());
         final Set<Tag> tagList = ParserUtil.parseTags(argMultimap.getAllValues(PREFIX_TAG));
 
         final MeetingEntry meetingEntry = new MeetingEntry(name, url, dateTime, moduleCode, recurringStatus, tagList);

--- a/src/test/java/seedu/address/logic/commands/AddCommandIntegrationTest.java
+++ b/src/test/java/seedu/address/logic/commands/AddCommandIntegrationTest.java
@@ -1,12 +1,13 @@
 package seedu.address.logic.commands;
 
 import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
-import static seedu.address.testutil.TypicalPersons.getTypicalAddressBook;
+import static seedu.address.testutil.TypicalMeetingEntries.getTypicalLinkyTime;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import seedu.address.logic.commands.meetingentry.AddCommand;
+import seedu.address.model.AddressBook;
 import seedu.address.model.LinkyTime;
 import seedu.address.model.Model;
 import seedu.address.model.ModelManager;
@@ -23,7 +24,7 @@ public class AddCommandIntegrationTest {
 
     @BeforeEach
     public void setUp() {
-        model = new ModelManager(getTypicalAddressBook(), new UserPrefs(), new LinkyTime());
+        model = new ModelManager(new AddressBook(), new UserPrefs(), getTypicalLinkyTime());
     }
 
     @Test

--- a/src/test/java/seedu/address/logic/commands/AddCommandIntegrationTest.java
+++ b/src/test/java/seedu/address/logic/commands/AddCommandIntegrationTest.java
@@ -28,9 +28,9 @@ public class AddCommandIntegrationTest {
 
     @Test
     public void execute_newMeetingEntry_success() {
-        MeetingEntry validMeetingEntry = new MeetingEntryBuilder().build();
+        final MeetingEntry validMeetingEntry = new MeetingEntryBuilder().build();
 
-        Model expectedModel = new ModelManager(model.getAddressBook(), new UserPrefs(), new LinkyTime());
+        final Model expectedModel = new ModelManager(model.getAddressBook(), new UserPrefs(), new LinkyTime());
         expectedModel.addMeetingEntry(validMeetingEntry);
 
         assertCommandSuccess(new AddCommand(validMeetingEntry), model,

--- a/src/test/java/seedu/address/logic/commands/AddCommandIntegrationTest.java
+++ b/src/test/java/seedu/address/logic/commands/AddCommandIntegrationTest.java
@@ -12,7 +12,9 @@ import seedu.address.model.LinkyTime;
 import seedu.address.model.Model;
 import seedu.address.model.ModelManager;
 import seedu.address.model.UserPrefs;
+import seedu.address.model.meetingentry.MeetingEntry;
 import seedu.address.model.person.Person;
+import seedu.address.testutil.MeetingEntryBuilder;
 import seedu.address.testutil.PersonBuilder;
 
 /**
@@ -39,9 +41,33 @@ public class AddCommandIntegrationTest {
     }
 
     @Test
+    public void execute_newMeetingEntry_success() {
+        MeetingEntry validMeetingEntry = new MeetingEntryBuilder().build();
+
+        Model expectedModel = new ModelManager(model.getAddressBook(), new UserPrefs(), new LinkyTime());
+        expectedModel.addMeetingEntry(validMeetingEntry);
+
+        assertCommandSuccess(new seedu.address.logic.commands.meetingentry.AddCommand(validMeetingEntry), model,
+                String.format(seedu.address.logic.commands.meetingentry.AddCommand.MESSAGE_SUCCESS,
+                        validMeetingEntry), expectedModel);
+    }
+
+    @Test
     public void execute_duplicatePerson_throwsCommandException() {
         Person personInList = model.getAddressBook().getPersonList().get(0);
         assertCommandFailure(new AddCommand(personInList), model, AddCommand.MESSAGE_DUPLICATE_PERSON);
     }
+
+    //      TODO implement the testcase when able to retrieve meetinglist
+    //    @Test
+    //    public void execute_duplicateMeetingEntry_throwsCommandException() {
+    //        MeetingEntry validMeetingEntry = new MeetingEntryBuilder().build();
+    //        Model expectedModel = new ModelManager(model.getAddressBook(), new UserPrefs(), new LinkyTime());
+    //        expectedModel.addMeetingEntry(validMeetingEntry);
+    //
+    //        MeetingEntry meetingEntryInList = model.getLinkyTime().getMeetingEntryList().get(0);
+    //        assertCommandFailure(new seedu.address.logic.commands.meetingentry.AddCommand(meetingEntryInList),
+    //        expectedModel, AddCommand.MESSAGE_DUPLICATE_PERSON);
+    //    }
 
 }

--- a/src/test/java/seedu/address/logic/commands/AddCommandIntegrationTest.java
+++ b/src/test/java/seedu/address/logic/commands/AddCommandIntegrationTest.java
@@ -8,7 +8,6 @@ import org.junit.jupiter.api.Test;
 
 import seedu.address.logic.commands.meetingentry.AddCommand;
 import seedu.address.model.AddressBook;
-import seedu.address.model.LinkyTime;
 import seedu.address.model.Model;
 import seedu.address.model.ModelManager;
 import seedu.address.model.UserPrefs;
@@ -31,7 +30,7 @@ public class AddCommandIntegrationTest {
     public void execute_newMeetingEntry_success() {
         final MeetingEntry validMeetingEntry = new MeetingEntryBuilder().build();
 
-        final Model expectedModel = new ModelManager(model.getAddressBook(), new UserPrefs(), new LinkyTime());
+        final Model expectedModel = new ModelManager(new AddressBook(), new UserPrefs(), model.getLinkyTime());
         expectedModel.addMeetingEntry(validMeetingEntry);
 
         assertCommandSuccess(new AddCommand(validMeetingEntry), model,

--- a/src/test/java/seedu/address/logic/commands/AddCommandIntegrationTest.java
+++ b/src/test/java/seedu/address/logic/commands/AddCommandIntegrationTest.java
@@ -1,21 +1,18 @@
 package seedu.address.logic.commands;
 
-import static seedu.address.logic.commands.CommandTestUtil.assertCommandFailure;
 import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
 import static seedu.address.testutil.TypicalPersons.getTypicalAddressBook;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-import seedu.address.logic.commands.person.AddCommand;
+import seedu.address.logic.commands.meetingentry.AddCommand;
 import seedu.address.model.LinkyTime;
 import seedu.address.model.Model;
 import seedu.address.model.ModelManager;
 import seedu.address.model.UserPrefs;
 import seedu.address.model.meetingentry.MeetingEntry;
-import seedu.address.model.person.Person;
 import seedu.address.testutil.MeetingEntryBuilder;
-import seedu.address.testutil.PersonBuilder;
 
 /**
  * Contains integration tests (interaction with the Model) for {@code AddCommand}.
@@ -30,33 +27,16 @@ public class AddCommandIntegrationTest {
     }
 
     @Test
-    public void execute_newPerson_success() {
-        Person validPerson = new PersonBuilder().build();
-
-        Model expectedModel = new ModelManager(model.getAddressBook(), new UserPrefs(), new LinkyTime());
-        expectedModel.addPerson(validPerson);
-
-        assertCommandSuccess(new AddCommand(validPerson), model,
-                String.format(AddCommand.MESSAGE_SUCCESS, validPerson), expectedModel);
-    }
-
-    @Test
     public void execute_newMeetingEntry_success() {
         MeetingEntry validMeetingEntry = new MeetingEntryBuilder().build();
 
         Model expectedModel = new ModelManager(model.getAddressBook(), new UserPrefs(), new LinkyTime());
         expectedModel.addMeetingEntry(validMeetingEntry);
 
-        assertCommandSuccess(new seedu.address.logic.commands.meetingentry.AddCommand(validMeetingEntry), model,
-                String.format(seedu.address.logic.commands.meetingentry.AddCommand.MESSAGE_SUCCESS,
-                        validMeetingEntry), expectedModel);
+        assertCommandSuccess(new AddCommand(validMeetingEntry), model,
+                String.format(AddCommand.MESSAGE_SUCCESS, validMeetingEntry), expectedModel);
     }
 
-    @Test
-    public void execute_duplicatePerson_throwsCommandException() {
-        Person personInList = model.getAddressBook().getPersonList().get(0);
-        assertCommandFailure(new AddCommand(personInList), model, AddCommand.MESSAGE_DUPLICATE_PERSON);
-    }
 
     //      TODO implement the testcase when able to retrieve meetinglist
     //    @Test

--- a/src/test/java/seedu/address/logic/commands/AddCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/AddCommandTest.java
@@ -36,10 +36,10 @@ public class AddCommandTest {
 
     @Test
     public void execute_meetingEntryAcceptedByModel_addSuccessful() throws Exception {
-        ModelStubAcceptingMeetingEntryAdded modelStub = new ModelStubAcceptingMeetingEntryAdded();
-        MeetingEntry validMeetingEntry = new MeetingEntryBuilder().build();
+        final ModelStubAcceptingMeetingEntryAdded modelStub = new ModelStubAcceptingMeetingEntryAdded();
+        final MeetingEntry validMeetingEntry = new MeetingEntryBuilder().build();
 
-        CommandResult commandResult = new AddCommand(validMeetingEntry).execute(modelStub);
+        final CommandResult commandResult = new AddCommand(validMeetingEntry).execute(modelStub);
 
         assertEquals(String.format(AddCommand.MESSAGE_SUCCESS, validMeetingEntry), commandResult.getFeedbackToUser());
         assertEquals(Arrays.asList(validMeetingEntry), modelStub.meetingEntriesAdded);
@@ -47,9 +47,9 @@ public class AddCommandTest {
 
     @Test
     public void execute_duplicateMeetingEntry_throwsCommandException() {
-        MeetingEntry validMeetingEntry = new MeetingEntryBuilder().build();
-        AddCommand addCommand = new AddCommand(validMeetingEntry);
-        ModelStub modelStub = new ModelStubWithMeetingEntry(validMeetingEntry);
+        final MeetingEntry validMeetingEntry = new MeetingEntryBuilder().build();
+        final AddCommand addCommand = new AddCommand(validMeetingEntry);
+        final ModelStub modelStub = new ModelStubWithMeetingEntry(validMeetingEntry);
 
         assertThrows(CommandException.class, AddCommand.MESSAGE_DUPLICATE_ENTRY, () -> addCommand.execute(modelStub));
     }
@@ -57,16 +57,16 @@ public class AddCommandTest {
     @Test
     public void equals() {
 
-        MeetingEntry cS2103 = new MeetingEntryBuilder().withName("CS2103").build();
-        MeetingEntry cS2101 = new MeetingEntryBuilder().withName("CS2101").build();
-        AddCommand addCS2103Command = new AddCommand(cS2103);
-        AddCommand addCS2101Command = new AddCommand(cS2101);
+        final MeetingEntry cs2103 = new MeetingEntryBuilder().withName("CS2103").build();
+        final MeetingEntry cs2101 = new MeetingEntryBuilder().withName("CS2101").build();
+        final AddCommand addCS2103Command = new AddCommand(cs2103);
+        final AddCommand addCS2101Command = new AddCommand(cs2101);
 
         // same object -> returns true
         assertTrue(addCS2103Command.equals(addCS2103Command));
 
         // same values -> returns true
-        AddCommand addCS2103CommandCopy = new AddCommand(cS2103);
+        final AddCommand addCS2103CommandCopy = new AddCommand(cs2103);
         assertTrue(addCS2103Command.equals(addCS2103CommandCopy));
 
         // different types -> returns false

--- a/src/test/java/seedu/address/logic/commands/AddCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/AddCommandTest.java
@@ -16,7 +16,7 @@ import org.junit.jupiter.api.Test;
 import javafx.collections.ObservableList;
 import seedu.address.commons.core.GuiSettings;
 import seedu.address.logic.commands.exceptions.CommandException;
-import seedu.address.logic.commands.person.AddCommand;
+import seedu.address.logic.commands.meetingentry.AddCommand;
 import seedu.address.model.AddressBook;
 import seedu.address.model.Model;
 import seedu.address.model.ReadOnlyAddressBook;
@@ -24,57 +24,59 @@ import seedu.address.model.ReadOnlyLinkyTime;
 import seedu.address.model.ReadOnlyUserPrefs;
 import seedu.address.model.meetingentry.MeetingEntry;
 import seedu.address.model.person.Person;
-import seedu.address.testutil.PersonBuilder;
+import seedu.address.testutil.MeetingEntryBuilder;
+
 
 public class AddCommandTest {
 
     @Test
-    public void constructor_nullPerson_throwsNullPointerException() {
+    public void constructor_nullMeetingEntry_throwsNullPointerException() {
         assertThrows(NullPointerException.class, () -> new AddCommand(null));
     }
 
     @Test
-    public void execute_personAcceptedByModel_addSuccessful() throws Exception {
-        ModelStubAcceptingPersonAdded modelStub = new ModelStubAcceptingPersonAdded();
-        Person validPerson = new PersonBuilder().build();
+    public void execute_meetingEntryAcceptedByModel_addSuccessful() throws Exception {
+        ModelStubAcceptingMeetingEntryAdded modelStub = new ModelStubAcceptingMeetingEntryAdded();
+        MeetingEntry validMeetingEntry = new MeetingEntryBuilder().build();
 
-        CommandResult commandResult = new AddCommand(validPerson).execute(modelStub);
+        CommandResult commandResult = new AddCommand(validMeetingEntry).execute(modelStub);
 
-        assertEquals(String.format(AddCommand.MESSAGE_SUCCESS, validPerson), commandResult.getFeedbackToUser());
-        assertEquals(Arrays.asList(validPerson), modelStub.personsAdded);
+        assertEquals(String.format(AddCommand.MESSAGE_SUCCESS, validMeetingEntry), commandResult.getFeedbackToUser());
+        assertEquals(Arrays.asList(validMeetingEntry), modelStub.meetingEntriesAdded);
     }
 
     @Test
-    public void execute_duplicatePerson_throwsCommandException() {
-        Person validPerson = new PersonBuilder().build();
-        AddCommand addCommand = new AddCommand(validPerson);
-        ModelStub modelStub = new ModelStubWithPerson(validPerson);
+    public void execute_duplicateMeetingEntry_throwsCommandException() {
+        MeetingEntry validMeetingEntry = new MeetingEntryBuilder().build();
+        AddCommand addCommand = new AddCommand(validMeetingEntry);
+        ModelStub modelStub = new ModelStubWithMeetingEntry(validMeetingEntry);
 
         assertThrows(CommandException.class, AddCommand.MESSAGE_DUPLICATE_PERSON, () -> addCommand.execute(modelStub));
     }
 
     @Test
     public void equals() {
-        Person alice = new PersonBuilder().withName("Alice").build();
-        Person bob = new PersonBuilder().withName("Bob").build();
-        AddCommand addAliceCommand = new AddCommand(alice);
-        AddCommand addBobCommand = new AddCommand(bob);
+
+        MeetingEntry cS2103 = new MeetingEntryBuilder().withName("CS2103").build();
+        MeetingEntry cS2101 = new MeetingEntryBuilder().withName("CS2101").build();
+        AddCommand addCS2103Command = new AddCommand(cS2103);
+        AddCommand addCS2101Command = new AddCommand(cS2101);
 
         // same object -> returns true
-        assertTrue(addAliceCommand.equals(addAliceCommand));
+        assertTrue(addCS2103Command.equals(addCS2103Command));
 
         // same values -> returns true
-        AddCommand addAliceCommandCopy = new AddCommand(alice);
-        assertTrue(addAliceCommand.equals(addAliceCommandCopy));
+        AddCommand addCS2103CommandCopy = new AddCommand(cS2103);
+        assertTrue(addCS2103Command.equals(addCS2103CommandCopy));
 
         // different types -> returns false
-        assertFalse(addAliceCommand.equals(1));
+        assertFalse(addCS2103Command.equals(1));
 
         // null -> returns false
-        assertFalse(addAliceCommand.equals(null));
+        assertFalse(addCS2103CommandCopy.equals(null));
 
         // different person -> returns false
-        assertFalse(addAliceCommand.equals(addBobCommand));
+        assertFalse(addCS2103Command.equals(addCS2101Command));
     }
 
     /**
@@ -202,40 +204,42 @@ public class AddCommandTest {
         }
     }
 
-    /**
-     * A Model stub that contains a single person.
-     */
-    private class ModelStubWithPerson extends ModelStub {
-        private final Person person;
 
-        ModelStubWithPerson(Person person) {
-            requireNonNull(person);
-            this.person = person;
+    /**
+     * A Model stub that contains a single meetingEntry.
+     */
+    private class ModelStubWithMeetingEntry extends ModelStub {
+        private final MeetingEntry meetingEntry;
+
+        ModelStubWithMeetingEntry(MeetingEntry meetingEntry) {
+            requireNonNull(meetingEntry);
+            this.meetingEntry = meetingEntry;
         }
 
         @Override
-        public boolean hasPerson(Person person) {
-            requireNonNull(person);
-            return this.person.isSamePerson(person);
+        public boolean hasMeetingEntry(MeetingEntry meetingEntry) {
+            requireNonNull(meetingEntry);
+            return this.meetingEntry.equals(meetingEntry);
         }
+
     }
 
     /**
-     * A Model stub that always accept the person being added.
+     * A Model stub that always accept the MeetingEntry being added.
      */
-    private class ModelStubAcceptingPersonAdded extends ModelStub {
-        final ArrayList<Person> personsAdded = new ArrayList<>();
+    private class ModelStubAcceptingMeetingEntryAdded extends ModelStub {
+        final ArrayList<MeetingEntry> meetingEntriesAdded = new ArrayList<>();
 
         @Override
-        public boolean hasPerson(Person person) {
-            requireNonNull(person);
-            return personsAdded.stream().anyMatch(person::isSamePerson);
+        public boolean hasMeetingEntry(MeetingEntry meetingEntry) {
+            requireNonNull(meetingEntry);
+            return meetingEntriesAdded.stream().anyMatch(meetingEntry::equals);
         }
 
         @Override
-        public void addPerson(Person person) {
-            requireNonNull(person);
-            personsAdded.add(person);
+        public void addMeetingEntry(MeetingEntry meetingEntry) {
+            requireNonNull(meetingEntry);
+            meetingEntriesAdded.add(meetingEntry);
         }
 
         @Override

--- a/src/test/java/seedu/address/logic/commands/AddCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/AddCommandTest.java
@@ -51,12 +51,12 @@ public class AddCommandTest {
         final AddCommand addCommand = new AddCommand(validMeetingEntry);
         final ModelStub modelStub = new ModelStubWithMeetingEntry(validMeetingEntry);
 
-        assertThrows(CommandException.class, AddCommand.MESSAGE_DUPLICATE_ENTRY, () -> addCommand.execute(modelStub));
+        assertThrows(CommandException.class, AddCommand.MESSAGE_DUPLICATE_MEETING_ENTRY,
+                () -> addCommand.execute(modelStub));
     }
 
     @Test
     public void equals() {
-
         final MeetingEntry cs2103 = new MeetingEntryBuilder().withName("CS2103").build();
         final MeetingEntry cs2101 = new MeetingEntryBuilder().withName("CS2101").build();
         final AddCommand addCS2103Command = new AddCommand(cs2103);
@@ -75,7 +75,7 @@ public class AddCommandTest {
         // null -> returns false
         assertFalse(addCS2103CommandCopy.equals(null));
 
-        // different person -> returns false
+        // different meeting entry -> returns false
         assertFalse(addCS2103Command.equals(addCS2101Command));
     }
 

--- a/src/test/java/seedu/address/logic/commands/AddCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/AddCommandTest.java
@@ -51,7 +51,7 @@ public class AddCommandTest {
         AddCommand addCommand = new AddCommand(validMeetingEntry);
         ModelStub modelStub = new ModelStubWithMeetingEntry(validMeetingEntry);
 
-        assertThrows(CommandException.class, AddCommand.MESSAGE_DUPLICATE_PERSON, () -> addCommand.execute(modelStub));
+        assertThrows(CommandException.class, AddCommand.MESSAGE_DUPLICATE_ENTRY, () -> addCommand.execute(modelStub));
     }
 
     @Test

--- a/src/test/java/seedu/address/logic/commands/AddCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/AddCommandTest.java
@@ -51,8 +51,8 @@ public class AddCommandTest {
         final AddCommand addCommand = new AddCommand(validMeetingEntry);
         final ModelStub modelStub = new ModelStubWithMeetingEntry(validMeetingEntry);
 
-        assertThrows(CommandException.class, AddCommand.MESSAGE_DUPLICATE_MEETING_ENTRY,
-                () -> addCommand.execute(modelStub));
+        assertThrows(CommandException.class,
+                AddCommand.MESSAGE_DUPLICATE_MEETING_ENTRY, () -> addCommand.execute(modelStub));
     }
 
     @Test

--- a/src/test/java/seedu/address/logic/commands/CommandTestUtil.java
+++ b/src/test/java/seedu/address/logic/commands/CommandTestUtil.java
@@ -3,10 +3,14 @@ package seedu.address.logic.commands;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_ADDRESS;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_DATETIME;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_EMAIL;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_MODULE_CODE;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_PHONE;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_RECURRING;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_URL;
 import static seedu.address.testutil.Assert.assertThrows;
 
 import java.util.ArrayList;
@@ -38,6 +42,32 @@ public class CommandTestUtil {
     public static final String VALID_TAG_HUSBAND = "husband";
     public static final String VALID_TAG_FRIEND = "friend";
 
+    public static final String VALID_NAME_LECTURE = "Lecture";
+    public static final String VALID_NAME_TUTORIAL = "Tutorial";
+    public static final String VALID_URL_LECTURE = "https://www.google.com";
+    public static final String VALID_URL_TUTORIAL = "https://www.zoom.com";
+    public static final String VALID_DATETIME_LECTURE = "Friday";
+    public static final String VALID_DATETIME_TUTORIAL = "Tuesday";
+    public static final String VALID_MODULE_CODE_LECTURE = "CS2103";
+    public static final String VALID_MODULE_CODE_TUTORIAL = "CS2101";
+    public static final String VALID_RECURRING_LECTURE = "Y";
+    public static final String VALID_RECURRING_TUTORIAL = "Y";
+    public static final String VALID_TAG_LECTURE = "damith";
+    public static final String VALID_TAG_TUTORIAL = "amy";
+
+    public static final String NAME_DESC_LECTURE = " " + PREFIX_NAME + VALID_NAME_LECTURE;
+    public static final String NAME_DESC_TUTORIAL = " " + PREFIX_NAME + VALID_NAME_TUTORIAL;
+    public static final String URL_DESC_LECTURE = " " + PREFIX_URL + VALID_URL_LECTURE;
+    public static final String URL_DESC_TUTORIAL = " " + PREFIX_URL + VALID_URL_TUTORIAL;
+    public static final String DATETIME_DESC_LECTURE = " " + PREFIX_DATETIME + VALID_DATETIME_LECTURE;
+    public static final String DATETIME_DESC_TUTORIAL = " " + PREFIX_DATETIME + VALID_DATETIME_TUTORIAL;
+    public static final String MODULE_CODE_DESC_LECTURE = " " + PREFIX_MODULE_CODE + VALID_MODULE_CODE_LECTURE;
+    public static final String MODULE_CODE_DESC_TUTORIAL = " " + PREFIX_MODULE_CODE + VALID_MODULE_CODE_TUTORIAL;
+    public static final String RECURRING_DESC_LECTURE = " " + PREFIX_RECURRING + VALID_RECURRING_LECTURE;
+    public static final String RECURRING_DESC_TUTORIAL = " " + PREFIX_RECURRING + VALID_RECURRING_TUTORIAL;
+    public static final String TAG_DESC_LECTURE = " " + PREFIX_TAG + VALID_TAG_LECTURE;
+    public static final String TAG_DESC_TUTORIAL = " " + PREFIX_TAG + VALID_TAG_TUTORIAL;
+
     public static final String NAME_DESC_AMY = " " + PREFIX_NAME + VALID_NAME_AMY;
     public static final String NAME_DESC_BOB = " " + PREFIX_NAME + VALID_NAME_BOB;
     public static final String PHONE_DESC_AMY = " " + PREFIX_PHONE + VALID_PHONE_AMY;
@@ -54,6 +84,15 @@ public class CommandTestUtil {
     public static final String INVALID_EMAIL_DESC = " " + PREFIX_EMAIL + "bob!yahoo"; // missing '@' symbol
     public static final String INVALID_ADDRESS_DESC = " " + PREFIX_ADDRESS; // empty string not allowed for addresses
     public static final String INVALID_TAG_DESC = " " + PREFIX_TAG + "hubby*"; // '*' not allowed in tags
+
+    //    TODO once we start validaint input
+    //    public static final String INVALID_NAME_DESC = " " + PREFIX_NAME + "James&"; // '&' not allowed in names
+    //    public static final String INVALID_URL_DESC = " " + PREFIX_PHONE + "911a"; // 'a' not allowed in phones
+    //    public static final String INVALID_DATETIME_DESC = " " + PREFIX_EMAIL + "bob!yahoo"; // missing '@' symbol
+    //    public static final String INVALID_MODULE_CODE_DESC = " " + PREFIX_ADDRESS; // empty string not allowed
+    //    public static final String INVALID_RECURRING_DESC = " " + PREFIX_TAG + "hubby*"; // '*' not allowed in tag
+    //    public static final String INVALID_TAG_DESC = " " + PREFIX_TAG + "hubby*"; // '*' not allowed in tags
+
 
     public static final String PREAMBLE_WHITESPACE = "\t  \r  \n";
     public static final String PREAMBLE_NON_EMPTY = "NonEmptyPreamble";

--- a/src/test/java/seedu/address/logic/commands/CommandTestUtil.java
+++ b/src/test/java/seedu/address/logic/commands/CommandTestUtil.java
@@ -51,7 +51,7 @@ public class CommandTestUtil {
     public static final String VALID_MODULE_CODE_LECTURE = "CS2103";
     public static final String VALID_MODULE_CODE_TUTORIAL = "CS2101";
     public static final String VALID_RECURRING_LECTURE = "Y";
-    public static final String VALID_RECURRING_TUTORIAL = "Y";
+    public static final String VALID_RECURRING_TUTORIAL = "N";
     public static final String VALID_TAG_LECTURE = "damith";
     public static final String VALID_TAG_TUTORIAL = "amy";
 
@@ -93,7 +93,6 @@ public class CommandTestUtil {
     //    public static final String INVALID_RECURRING_DESC = " " + PREFIX_TAG + "hubby*"; // '*' not allowed in tag
     //    public static final String INVALID_TAG_DESC = " " + PREFIX_TAG + "hubby*"; // '*' not allowed in tags
 
-
     public static final String PREAMBLE_WHITESPACE = "\t  \r  \n";
     public static final String PREAMBLE_NON_EMPTY = "NonEmptyPreamble";
 
@@ -115,7 +114,7 @@ public class CommandTestUtil {
      * - the {@code actualModel} matches {@code expectedModel}
      */
     public static void assertCommandSuccess(Command command, Model actualModel, CommandResult expectedCommandResult,
-                                            Model expectedModel) {
+            Model expectedModel) {
         try {
             final CommandResult result = command.execute(actualModel);
             assertEquals(expectedCommandResult, result);
@@ -130,7 +129,7 @@ public class CommandTestUtil {
      * that takes a string {@code expectedMessage}.
      */
     public static void assertCommandSuccess(Command command, Model actualModel, String expectedMessage,
-                                            Model expectedModel) {
+            Model expectedModel) {
         final CommandResult expectedCommandResult = new CommandResult(expectedMessage);
         assertCommandSuccess(command, actualModel, expectedCommandResult, expectedModel);
     }

--- a/src/test/java/seedu/address/logic/commands/CommandTestUtil.java
+++ b/src/test/java/seedu/address/logic/commands/CommandTestUtil.java
@@ -85,7 +85,7 @@ public class CommandTestUtil {
     public static final String INVALID_ADDRESS_DESC = " " + PREFIX_ADDRESS; // empty string not allowed for addresses
     public static final String INVALID_TAG_DESC = " " + PREFIX_TAG + "hubby*"; // '*' not allowed in tags
 
-    //    TODO once we start validaint input
+    //    TODO once we start validating input
     //    public static final String INVALID_NAME_DESC = " " + PREFIX_NAME + "James&"; // '&' not allowed in names
     //    public static final String INVALID_URL_DESC = " " + PREFIX_PHONE + "911a"; // 'a' not allowed in phones
     //    public static final String INVALID_DATETIME_DESC = " " + PREFIX_EMAIL + "bob!yahoo"; // missing '@' symbol
@@ -115,9 +115,9 @@ public class CommandTestUtil {
      * - the {@code actualModel} matches {@code expectedModel}
      */
     public static void assertCommandSuccess(Command command, Model actualModel, CommandResult expectedCommandResult,
-            Model expectedModel) {
+                                            Model expectedModel) {
         try {
-            CommandResult result = command.execute(actualModel);
+            final CommandResult result = command.execute(actualModel);
             assertEquals(expectedCommandResult, result);
             assertEquals(expectedModel, actualModel);
         } catch (CommandException ce) {
@@ -130,8 +130,8 @@ public class CommandTestUtil {
      * that takes a string {@code expectedMessage}.
      */
     public static void assertCommandSuccess(Command command, Model actualModel, String expectedMessage,
-            Model expectedModel) {
-        CommandResult expectedCommandResult = new CommandResult(expectedMessage);
+                                            Model expectedModel) {
+        final CommandResult expectedCommandResult = new CommandResult(expectedMessage);
         assertCommandSuccess(command, actualModel, expectedCommandResult, expectedModel);
     }
 
@@ -144,13 +144,14 @@ public class CommandTestUtil {
     public static void assertCommandFailure(Command command, Model actualModel, String expectedMessage) {
         // we are unable to defensively copy the model for comparison later, so we can
         // only do so by copying its components.
-        AddressBook expectedAddressBook = new AddressBook(actualModel.getAddressBook());
-        List<Person> expectedFilteredList = new ArrayList<>(actualModel.getFilteredPersonList());
+        final AddressBook expectedAddressBook = new AddressBook(actualModel.getAddressBook());
+        final List<Person> expectedFilteredList = new ArrayList<>(actualModel.getFilteredPersonList());
 
         assertThrows(CommandException.class, expectedMessage, () -> command.execute(actualModel));
         assertEquals(expectedAddressBook, actualModel.getAddressBook());
         assertEquals(expectedFilteredList, actualModel.getFilteredPersonList());
     }
+
     /**
      * Updates {@code model}'s filtered list to show only the person at the given {@code targetIndex} in the
      * {@code model}'s address book.
@@ -158,7 +159,7 @@ public class CommandTestUtil {
     public static void showPersonAtIndex(Model model, Index targetIndex) {
         assertTrue(targetIndex.getZeroBased() < model.getFilteredPersonList().size());
 
-        Person person = model.getFilteredPersonList().get(targetIndex.getZeroBased());
+        final Person person = model.getFilteredPersonList().get(targetIndex.getZeroBased());
         final String[] splitName = person.getName().fullName.split("\\s+");
         model.updateFilteredPersonList(new NameContainsKeywordsPredicate(Arrays.asList(splitName[0])));
 

--- a/src/test/java/seedu/address/logic/parser/AddCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/AddCommandParserTest.java
@@ -34,11 +34,11 @@ import seedu.address.model.meetingentry.MeetingEntry;
 import seedu.address.testutil.MeetingEntryBuilder;
 
 public class AddCommandParserTest {
-    private AddCommandParser parser = new AddCommandParser();
+    private final AddCommandParser parser = new AddCommandParser();
 
     @Test
     public void parse_allFieldsPresent_success() {
-        MeetingEntry expectedMeetingEntry = new MeetingEntryBuilder(CS2103).build();
+        final MeetingEntry expectedMeetingEntry = new MeetingEntryBuilder(CS2103).build();
 
         // whitespace only preamble
         assertParseSuccess(parser, PREAMBLE_WHITESPACE + NAME_DESC_LECTURE + URL_DESC_LECTURE
@@ -71,17 +71,17 @@ public class AddCommandParserTest {
                 + TAG_DESC_LECTURE, new AddCommand(expectedMeetingEntry));
 
         // multiple tags - all accepted
-        MeetingEntry expectedMeetingEntryMultipleTags = new MeetingEntryBuilder(CS2103)
+        final MeetingEntry expectedMeetingEntryMultipleTags = new MeetingEntryBuilder(CS2103)
                 .withTags(VALID_TAG_LECTURE, VALID_TAG_TUTORIAL).build();
         assertParseSuccess(parser, NAME_DESC_LECTURE + URL_DESC_LECTURE + DATETIME_DESC_LECTURE
                 + MODULE_CODE_DESC_LECTURE + RECURRING_DESC_LECTURE + TAG_DESC_TUTORIAL
-                + TAG_DESC_LECTURE , new AddCommand(expectedMeetingEntryMultipleTags));
+                + TAG_DESC_LECTURE, new AddCommand(expectedMeetingEntryMultipleTags));
     }
 
     @Test
     public void parse_optionalFieldsMissing_success() {
         // zero tags
-        MeetingEntry expectedMeetingEntry = new MeetingEntryBuilder(CS2101).withTags().build();
+        final MeetingEntry expectedMeetingEntry = new MeetingEntryBuilder(CS2101).withTags().build();
         assertParseSuccess(parser, NAME_DESC_TUTORIAL + URL_DESC_TUTORIAL + DATETIME_DESC_TUTORIAL
                         + MODULE_CODE_DESC_TUTORIAL + RECURRING_DESC_TUTORIAL,
                 new AddCommand(expectedMeetingEntry));
@@ -89,7 +89,7 @@ public class AddCommandParserTest {
 
     @Test
     public void parse_compulsoryFieldMissing_failure() {
-        String expectedMessage = String.format(MESSAGE_INVALID_COMMAND_FORMAT, AddCommand.MESSAGE_USAGE);
+        final String expectedMessage = String.format(MESSAGE_INVALID_COMMAND_FORMAT, AddCommand.MESSAGE_USAGE);
 
         // missing name prefix
         assertParseFailure(parser, VALID_NAME_LECTURE + URL_DESC_LECTURE + DATETIME_DESC_LECTURE

--- a/src/test/java/seedu/address/logic/parser/AddCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/AddCommandParserTest.java
@@ -1,86 +1,90 @@
 package seedu.address.logic.parser;
 
 import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
-import static seedu.address.logic.commands.CommandTestUtil.ADDRESS_DESC_AMY;
-import static seedu.address.logic.commands.CommandTestUtil.ADDRESS_DESC_BOB;
-import static seedu.address.logic.commands.CommandTestUtil.EMAIL_DESC_AMY;
-import static seedu.address.logic.commands.CommandTestUtil.EMAIL_DESC_BOB;
-import static seedu.address.logic.commands.CommandTestUtil.INVALID_ADDRESS_DESC;
-import static seedu.address.logic.commands.CommandTestUtil.INVALID_EMAIL_DESC;
-import static seedu.address.logic.commands.CommandTestUtil.INVALID_NAME_DESC;
-import static seedu.address.logic.commands.CommandTestUtil.INVALID_PHONE_DESC;
-import static seedu.address.logic.commands.CommandTestUtil.INVALID_TAG_DESC;
-import static seedu.address.logic.commands.CommandTestUtil.NAME_DESC_AMY;
-import static seedu.address.logic.commands.CommandTestUtil.NAME_DESC_BOB;
-import static seedu.address.logic.commands.CommandTestUtil.PHONE_DESC_AMY;
-import static seedu.address.logic.commands.CommandTestUtil.PHONE_DESC_BOB;
-import static seedu.address.logic.commands.CommandTestUtil.PREAMBLE_NON_EMPTY;
+import static seedu.address.logic.commands.CommandTestUtil.DATETIME_DESC_LECTURE;
+import static seedu.address.logic.commands.CommandTestUtil.DATETIME_DESC_TUTORIAL;
+import static seedu.address.logic.commands.CommandTestUtil.MODULE_CODE_DESC_LECTURE;
+import static seedu.address.logic.commands.CommandTestUtil.MODULE_CODE_DESC_TUTORIAL;
+import static seedu.address.logic.commands.CommandTestUtil.NAME_DESC_LECTURE;
+import static seedu.address.logic.commands.CommandTestUtil.NAME_DESC_TUTORIAL;
 import static seedu.address.logic.commands.CommandTestUtil.PREAMBLE_WHITESPACE;
-import static seedu.address.logic.commands.CommandTestUtil.TAG_DESC_FRIEND;
-import static seedu.address.logic.commands.CommandTestUtil.TAG_DESC_HUSBAND;
-import static seedu.address.logic.commands.CommandTestUtil.VALID_ADDRESS_BOB;
-import static seedu.address.logic.commands.CommandTestUtil.VALID_EMAIL_BOB;
-import static seedu.address.logic.commands.CommandTestUtil.VALID_NAME_BOB;
-import static seedu.address.logic.commands.CommandTestUtil.VALID_PHONE_BOB;
-import static seedu.address.logic.commands.CommandTestUtil.VALID_TAG_FRIEND;
-import static seedu.address.logic.commands.CommandTestUtil.VALID_TAG_HUSBAND;
+import static seedu.address.logic.commands.CommandTestUtil.RECURRING_DESC_LECTURE;
+import static seedu.address.logic.commands.CommandTestUtil.RECURRING_DESC_TUTORIAL;
+import static seedu.address.logic.commands.CommandTestUtil.TAG_DESC_LECTURE;
+import static seedu.address.logic.commands.CommandTestUtil.TAG_DESC_TUTORIAL;
+import static seedu.address.logic.commands.CommandTestUtil.URL_DESC_LECTURE;
+import static seedu.address.logic.commands.CommandTestUtil.URL_DESC_TUTORIAL;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_DATETIME_LECTURE;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_MODULE_CODE_LECTURE;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_NAME_LECTURE;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_RECURRING_LECTURE;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_TAG_LECTURE;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_TAG_TUTORIAL;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_URL_LECTURE;
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseFailure;
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseSuccess;
-import static seedu.address.testutil.TypicalPersons.AMY;
-import static seedu.address.testutil.TypicalPersons.BOB;
+import static seedu.address.testutil.TypicalMeetingEntries.CS2101;
+import static seedu.address.testutil.TypicalMeetingEntries.CS2103;
 
 import org.junit.jupiter.api.Test;
 
-import seedu.address.logic.commands.person.AddCommand;
-import seedu.address.logic.parser.person.AddCommandParser;
-import seedu.address.model.person.Address;
-import seedu.address.model.person.Email;
-import seedu.address.model.person.Name;
-import seedu.address.model.person.Person;
-import seedu.address.model.person.Phone;
-import seedu.address.model.tag.Tag;
-import seedu.address.testutil.PersonBuilder;
+import seedu.address.logic.commands.meetingentry.AddCommand;
+import seedu.address.logic.parser.meetingentry.AddCommandParser;
+import seedu.address.model.meetingentry.MeetingEntry;
+import seedu.address.testutil.MeetingEntryBuilder;
 
 public class AddCommandParserTest {
     private AddCommandParser parser = new AddCommandParser();
 
     @Test
     public void parse_allFieldsPresent_success() {
-        Person expectedPerson = new PersonBuilder(BOB).withTags(VALID_TAG_FRIEND).build();
+        MeetingEntry expectedMeetingEntry = new MeetingEntryBuilder(CS2103).build();
 
         // whitespace only preamble
-        assertParseSuccess(parser, PREAMBLE_WHITESPACE + NAME_DESC_BOB + PHONE_DESC_BOB + EMAIL_DESC_BOB
-                + ADDRESS_DESC_BOB + TAG_DESC_FRIEND, new AddCommand(expectedPerson));
+        assertParseSuccess(parser, PREAMBLE_WHITESPACE + NAME_DESC_LECTURE + URL_DESC_LECTURE
+                + DATETIME_DESC_LECTURE + MODULE_CODE_DESC_LECTURE + RECURRING_DESC_LECTURE
+                + TAG_DESC_LECTURE, new AddCommand(expectedMeetingEntry));
 
         // multiple names - last name accepted
-        assertParseSuccess(parser, NAME_DESC_AMY + NAME_DESC_BOB + PHONE_DESC_BOB + EMAIL_DESC_BOB
-                + ADDRESS_DESC_BOB + TAG_DESC_FRIEND, new AddCommand(expectedPerson));
+        assertParseSuccess(parser, NAME_DESC_TUTORIAL + NAME_DESC_LECTURE + URL_DESC_LECTURE
+                + DATETIME_DESC_LECTURE + MODULE_CODE_DESC_LECTURE + RECURRING_DESC_LECTURE
+                + TAG_DESC_LECTURE, new AddCommand(expectedMeetingEntry));
 
-        // multiple phones - last phone accepted
-        assertParseSuccess(parser, NAME_DESC_BOB + PHONE_DESC_AMY + PHONE_DESC_BOB + EMAIL_DESC_BOB
-                + ADDRESS_DESC_BOB + TAG_DESC_FRIEND, new AddCommand(expectedPerson));
+        // multiple urls - last url accepted
+        assertParseSuccess(parser, NAME_DESC_LECTURE + URL_DESC_TUTORIAL + URL_DESC_LECTURE
+                + DATETIME_DESC_LECTURE + MODULE_CODE_DESC_LECTURE + RECURRING_DESC_LECTURE
+                + TAG_DESC_LECTURE, new AddCommand(expectedMeetingEntry));
 
-        // multiple emails - last email accepted
-        assertParseSuccess(parser, NAME_DESC_BOB + PHONE_DESC_BOB + EMAIL_DESC_AMY + EMAIL_DESC_BOB
-                + ADDRESS_DESC_BOB + TAG_DESC_FRIEND, new AddCommand(expectedPerson));
+        // multiple datetime - last datetime accepted
+        assertParseSuccess(parser, NAME_DESC_LECTURE + URL_DESC_LECTURE + DATETIME_DESC_TUTORIAL
+                + DATETIME_DESC_LECTURE + MODULE_CODE_DESC_LECTURE + RECURRING_DESC_LECTURE
+                + TAG_DESC_LECTURE, new AddCommand(expectedMeetingEntry));
 
-        // multiple addresses - last address accepted
-        assertParseSuccess(parser, NAME_DESC_BOB + PHONE_DESC_BOB + EMAIL_DESC_BOB + ADDRESS_DESC_AMY
-                + ADDRESS_DESC_BOB + TAG_DESC_FRIEND, new AddCommand(expectedPerson));
+        // multiple module code - last module code accepted
+        assertParseSuccess(parser, NAME_DESC_LECTURE + URL_DESC_LECTURE + DATETIME_DESC_LECTURE
+                + MODULE_CODE_DESC_TUTORIAL + MODULE_CODE_DESC_LECTURE + RECURRING_DESC_LECTURE
+                + TAG_DESC_LECTURE, new AddCommand(expectedMeetingEntry));
+
+        // multiple recurrence - last recurrence accepted
+        assertParseSuccess(parser, NAME_DESC_LECTURE + URL_DESC_LECTURE + DATETIME_DESC_LECTURE
+                + MODULE_CODE_DESC_LECTURE + RECURRING_DESC_TUTORIAL + RECURRING_DESC_LECTURE
+                + TAG_DESC_LECTURE, new AddCommand(expectedMeetingEntry));
 
         // multiple tags - all accepted
-        Person expectedPersonMultipleTags = new PersonBuilder(BOB).withTags(VALID_TAG_FRIEND, VALID_TAG_HUSBAND)
-                .build();
-        assertParseSuccess(parser, NAME_DESC_BOB + PHONE_DESC_BOB + EMAIL_DESC_BOB + ADDRESS_DESC_BOB
-                + TAG_DESC_HUSBAND + TAG_DESC_FRIEND, new AddCommand(expectedPersonMultipleTags));
+        MeetingEntry expectedMeetingEntryMultipleTags = new MeetingEntryBuilder(CS2103)
+                .withTags(VALID_TAG_LECTURE, VALID_TAG_TUTORIAL).build();
+        assertParseSuccess(parser, NAME_DESC_LECTURE + URL_DESC_LECTURE + DATETIME_DESC_LECTURE
+                + MODULE_CODE_DESC_LECTURE + RECURRING_DESC_LECTURE + TAG_DESC_TUTORIAL
+                + TAG_DESC_LECTURE , new AddCommand(expectedMeetingEntryMultipleTags));
     }
 
     @Test
     public void parse_optionalFieldsMissing_success() {
         // zero tags
-        Person expectedPerson = new PersonBuilder(AMY).withTags().build();
-        assertParseSuccess(parser, NAME_DESC_AMY + PHONE_DESC_AMY + EMAIL_DESC_AMY + ADDRESS_DESC_AMY,
-                new AddCommand(expectedPerson));
+        MeetingEntry expectedMeetingEntry = new MeetingEntryBuilder(CS2101).withTags().build();
+        assertParseSuccess(parser, NAME_DESC_TUTORIAL + URL_DESC_TUTORIAL + DATETIME_DESC_TUTORIAL
+                        + MODULE_CODE_DESC_TUTORIAL + RECURRING_DESC_TUTORIAL,
+                new AddCommand(expectedMeetingEntry));
     }
 
     @Test
@@ -88,55 +92,68 @@ public class AddCommandParserTest {
         String expectedMessage = String.format(MESSAGE_INVALID_COMMAND_FORMAT, AddCommand.MESSAGE_USAGE);
 
         // missing name prefix
-        assertParseFailure(parser, VALID_NAME_BOB + PHONE_DESC_BOB + EMAIL_DESC_BOB + ADDRESS_DESC_BOB,
+        assertParseFailure(parser, VALID_NAME_LECTURE + URL_DESC_LECTURE + DATETIME_DESC_LECTURE
+                        + MODULE_CODE_DESC_LECTURE + RECURRING_DESC_LECTURE,
                 expectedMessage);
 
-        // missing phone prefix
-        assertParseFailure(parser, NAME_DESC_BOB + VALID_PHONE_BOB + EMAIL_DESC_BOB + ADDRESS_DESC_BOB,
+        // missing url prefix
+        assertParseFailure(parser, NAME_DESC_LECTURE + VALID_URL_LECTURE + DATETIME_DESC_LECTURE
+                        + MODULE_CODE_DESC_LECTURE + RECURRING_DESC_LECTURE,
                 expectedMessage);
 
-        // missing email prefix
-        assertParseFailure(parser, NAME_DESC_BOB + PHONE_DESC_BOB + VALID_EMAIL_BOB + ADDRESS_DESC_BOB,
+        // missing datetime prefix
+        assertParseFailure(parser, NAME_DESC_LECTURE + URL_DESC_LECTURE + VALID_DATETIME_LECTURE
+                        + MODULE_CODE_DESC_LECTURE + RECURRING_DESC_LECTURE,
                 expectedMessage);
 
-        // missing address prefix
-        assertParseFailure(parser, NAME_DESC_BOB + PHONE_DESC_BOB + EMAIL_DESC_BOB + VALID_ADDRESS_BOB,
+        // missing module code prefix
+        assertParseFailure(parser, NAME_DESC_LECTURE + URL_DESC_LECTURE + DATETIME_DESC_LECTURE
+                        + VALID_MODULE_CODE_LECTURE + RECURRING_DESC_LECTURE,
+                expectedMessage);
+
+        //missing recurrence prefix
+        assertParseFailure(parser, NAME_DESC_LECTURE + URL_DESC_LECTURE + DATETIME_DESC_LECTURE
+                        + MODULE_CODE_DESC_LECTURE + VALID_RECURRING_LECTURE,
                 expectedMessage);
 
         // all prefixes missing
-        assertParseFailure(parser, VALID_NAME_BOB + VALID_PHONE_BOB + VALID_EMAIL_BOB + VALID_ADDRESS_BOB,
+        assertParseFailure(parser, VALID_NAME_LECTURE + VALID_URL_LECTURE + VALID_DATETIME_LECTURE
+                        + VALID_MODULE_CODE_LECTURE + VALID_RECURRING_LECTURE,
                 expectedMessage);
     }
 
-    @Test
-    public void parse_invalidValue_failure() {
-        // invalid name
-        assertParseFailure(parser, INVALID_NAME_DESC + PHONE_DESC_BOB + EMAIL_DESC_BOB + ADDRESS_DESC_BOB
-                + TAG_DESC_HUSBAND + TAG_DESC_FRIEND, Name.MESSAGE_CONSTRAINTS);
-
-        // invalid phone
-        assertParseFailure(parser, NAME_DESC_BOB + INVALID_PHONE_DESC + EMAIL_DESC_BOB + ADDRESS_DESC_BOB
-                + TAG_DESC_HUSBAND + TAG_DESC_FRIEND, Phone.MESSAGE_CONSTRAINTS);
-
-        // invalid email
-        assertParseFailure(parser, NAME_DESC_BOB + PHONE_DESC_BOB + INVALID_EMAIL_DESC + ADDRESS_DESC_BOB
-                + TAG_DESC_HUSBAND + TAG_DESC_FRIEND, Email.MESSAGE_CONSTRAINTS);
-
-        // invalid address
-        assertParseFailure(parser, NAME_DESC_BOB + PHONE_DESC_BOB + EMAIL_DESC_BOB + INVALID_ADDRESS_DESC
-                + TAG_DESC_HUSBAND + TAG_DESC_FRIEND, Address.MESSAGE_CONSTRAINTS);
-
-        // invalid tag
-        assertParseFailure(parser, NAME_DESC_BOB + PHONE_DESC_BOB + EMAIL_DESC_BOB + ADDRESS_DESC_BOB
-                + INVALID_TAG_DESC + VALID_TAG_FRIEND, Tag.MESSAGE_CONSTRAINTS);
-
-        // two invalid values, only first invalid value reported
-        assertParseFailure(parser, INVALID_NAME_DESC + PHONE_DESC_BOB + EMAIL_DESC_BOB + INVALID_ADDRESS_DESC,
-                Name.MESSAGE_CONSTRAINTS);
-
-        // non-empty preamble
-        assertParseFailure(parser, PREAMBLE_NON_EMPTY + NAME_DESC_BOB + PHONE_DESC_BOB + EMAIL_DESC_BOB
-                + ADDRESS_DESC_BOB + TAG_DESC_HUSBAND + TAG_DESC_FRIEND,
-                String.format(MESSAGE_INVALID_COMMAND_FORMAT, AddCommand.MESSAGE_USAGE));
-    }
+    //      TODO update once we do input validation
+    //    @Test
+    //    public void parse_invalidValue_failure() {
+    //        // invalid name
+    //        seedu.address.logic.parser.person.AddCommandParser oldParser = new seedu.address.logic.parser
+    //        .person.AddCommandParser();
+    //        assertParseFailure(oldParser, INVALID_NAME_DESC + PHONE_DESC_BOB + EMAIL_DESC_BOB + ADDRESS_DESC_BOB
+    //                + TAG_DESC_HUSBAND + TAG_DESC_FRIEND, Name.MESSAGE_CONSTRAINTS);
+    //
+    //        // invalid phone
+    //        assertParseFailure(oldParser, NAME_DESC_BOB + INVALID_PHONE_DESC + EMAIL_DESC_BOB + ADDRESS_DESC_BOB
+    //                + TAG_DESC_HUSBAND + TAG_DESC_FRIEND, Phone.MESSAGE_CONSTRAINTS);
+    //
+    //        // invalid email
+    //        assertParseFailure(oldParser, NAME_DESC_BOB + PHONE_DESC_BOB + INVALID_EMAIL_DESC + ADDRESS_DESC_BOB
+    //                + TAG_DESC_HUSBAND + TAG_DESC_FRIEND, Email.MESSAGE_CONSTRAINTS);
+    //
+    //        // invalid address
+    //        assertParseFailure(oldParser, NAME_DESC_BOB + PHONE_DESC_BOB + EMAIL_DESC_BOB + INVALID_ADDRESS_DESC
+    //                + TAG_DESC_HUSBAND + TAG_DESC_FRIEND, Address.MESSAGE_CONSTRAINTS);
+    //
+    //        // invalid tag
+    //        assertParseFailure(oldParser, NAME_DESC_BOB + PHONE_DESC_BOB + EMAIL_DESC_BOB + ADDRESS_DESC_BOB
+    //                + INVALID_TAG_DESC + VALID_TAG_FRIEND, Tag.MESSAGE_CONSTRAINTS);
+    //
+    //        // two invalid values, only first invalid value reported
+    //        assertParseFailure(oldParser, INVALID_NAME_DESC + PHONE_DESC_BOB + EMAIL_DESC_BOB + INVALID_ADDRESS_DESC,
+    //                Name.MESSAGE_CONSTRAINTS);
+    //
+    //        // non-empty preamble
+    //        assertParseFailure(oldParser, PREAMBLE_NON_EMPTY + NAME_DESC_BOB + PHONE_DESC_BOB + EMAIL_DESC_BOB
+    //                + ADDRESS_DESC_BOB + TAG_DESC_HUSBAND + TAG_DESC_FRIEND,
+    //                String.format(MESSAGE_INVALID_COMMAND_FORMAT, AddCommand.MESSAGE_USAGE));
+    //    }
 }

--- a/src/test/java/seedu/address/testutil/MeetingEntryBuilder.java
+++ b/src/test/java/seedu/address/testutil/MeetingEntryBuilder.java
@@ -65,7 +65,7 @@ public class MeetingEntryBuilder {
     /**
      * Parses the {@code tags} into a {@code Set<Tag>} and set it to the {@code MeetingEntry} that we are building.
      */
-    public MeetingEntryBuilder withTags(String ... tags) {
+    public MeetingEntryBuilder withTags(String... tags) {
         this.tags = SampleDataUtil.getTagSet(tags);
         return this;
     }

--- a/src/test/java/seedu/address/testutil/MeetingEntryBuilder.java
+++ b/src/test/java/seedu/address/testutil/MeetingEntryBuilder.java
@@ -1,0 +1,109 @@
+package seedu.address.testutil;
+
+import java.util.HashSet;
+import java.util.Set;
+
+import seedu.address.model.meetingentry.IsRecurring;
+import seedu.address.model.meetingentry.MeetingDateTime;
+import seedu.address.model.meetingentry.MeetingEntry;
+import seedu.address.model.meetingentry.MeetingName;
+import seedu.address.model.meetingentry.MeetingUrl;
+import seedu.address.model.modulecode.ModuleCode;
+import seedu.address.model.tag.Tag;
+import seedu.address.model.util.SampleDataUtil;
+
+/**
+ * A utility class to help with building Person objects.
+ */
+public class MeetingEntryBuilder {
+
+    public static final String DEFAULT_NAME = "Lecture";
+    public static final String DEFAULT_URL = "https://www.zoom.com";
+    public static final String DEFAULT_DATETIME = "Tuesday";
+    public static final String DEFAULT_MODULE_CODE = "CS2101";
+    public static final String DEFAULT_RECURRENCE = "Y";
+
+    private MeetingName name;
+    private MeetingUrl url;
+    private MeetingDateTime dateTime;
+    private ModuleCode moduleCode;
+    private IsRecurring isRecurring;
+    private Set<Tag> tags;
+
+    /**
+     * Creates a {@code MeetingEntryBuilder} with the default details.
+     */
+    public MeetingEntryBuilder() {
+        name = new MeetingName(DEFAULT_NAME);
+        url = new MeetingUrl(DEFAULT_URL);
+        dateTime = new MeetingDateTime(DEFAULT_DATETIME);
+        moduleCode = new ModuleCode(DEFAULT_MODULE_CODE);
+        isRecurring = new IsRecurring(DEFAULT_RECURRENCE);
+        tags = new HashSet<>();
+    }
+
+    /**
+     * Initializes the MeetingEntryBuilder with the data of {@code meetingEntryToCopy}.
+     */
+    public MeetingEntryBuilder(MeetingEntry meetingEntryToCopy) {
+        name = meetingEntryToCopy.getName();
+        url = meetingEntryToCopy.getUrl();
+        dateTime = meetingEntryToCopy.getDateTime();
+        moduleCode = meetingEntryToCopy.getModuleCode();
+        isRecurring = meetingEntryToCopy.getIsRecurring();
+        tags = new HashSet<>(meetingEntryToCopy.getTags());
+    }
+
+    /**
+     * Sets the {@code MeetingName} of the {@code MeetingEntry} that we are building.
+     */
+    public MeetingEntryBuilder withName(String name) {
+        this.name = new MeetingName(name);
+        return this;
+    }
+
+    /**
+     * Parses the {@code tags} into a {@code Set<Tag>} and set it to the {@code MeetingEntry} that we are building.
+     */
+    public MeetingEntryBuilder withTags(String ... tags) {
+        this.tags = SampleDataUtil.getTagSet(tags);
+        return this;
+    }
+
+    /**
+     * Sets the {@code MeetingUrl} of the {@code MeetingEntry} that we are building.
+     */
+    public MeetingEntryBuilder withUrl(String url) {
+        this.url = new MeetingUrl(url);
+        return this;
+    }
+
+    /**
+     * Sets the {@code DateTime} of the {@code MeetingEntry} that we are building.
+     */
+    public MeetingEntryBuilder withDateTime(String dateTime) {
+        this.dateTime = new MeetingDateTime(dateTime);
+        return this;
+    }
+
+    /**
+     * Sets the {@code ModuleCode} of the {@code MeetingEntry} that we are building.
+     */
+    public MeetingEntryBuilder withModuleCode(String moduleCode) {
+        this.moduleCode = new ModuleCode(moduleCode);
+        return this;
+    }
+
+    /**
+     * Sets the {@code IsRecurring} of the {@code MeetingEntry} that we are building.
+     */
+    public MeetingEntryBuilder withIsRecurring(String isRecurring) {
+        this.isRecurring = new IsRecurring(isRecurring);
+        return this;
+    }
+
+    public MeetingEntry build() {
+        return new MeetingEntry(name, url, dateTime, moduleCode, isRecurring, tags);
+    }
+
+}

--- a/src/test/java/seedu/address/testutil/MeetingEntryBuilder.java
+++ b/src/test/java/seedu/address/testutil/MeetingEntryBuilder.java
@@ -16,7 +16,6 @@ import seedu.address.model.util.SampleDataUtil;
  * A utility class to help with building MeetingEntry objects.
  */
 public class MeetingEntryBuilder {
-
     public static final String DEFAULT_NAME = "Lecture";
     public static final String DEFAULT_URL = "https://www.zoom.com";
     public static final String DEFAULT_DATETIME = "Tuesday";

--- a/src/test/java/seedu/address/testutil/MeetingEntryBuilder.java
+++ b/src/test/java/seedu/address/testutil/MeetingEntryBuilder.java
@@ -13,7 +13,7 @@ import seedu.address.model.tag.Tag;
 import seedu.address.model.util.SampleDataUtil;
 
 /**
- * A utility class to help with building Person objects.
+ * A utility class to help with building MeetingEntry objects.
  */
 public class MeetingEntryBuilder {
 

--- a/src/test/java/seedu/address/testutil/TypicalMeetingEntries.java
+++ b/src/test/java/seedu/address/testutil/TypicalMeetingEntries.java
@@ -21,7 +21,7 @@ import seedu.address.model.LinkyTime;
 import seedu.address.model.meetingentry.MeetingEntry;
 
 /**
- * A utility class containing a list of {@code Person} objects to be used in tests.
+ * A utility class containing a list of {@code MeetingEntry} objects to be used in tests.
  */
 public class TypicalMeetingEntries {
 
@@ -70,12 +70,12 @@ public class TypicalMeetingEntries {
             .withModuleCode(VALID_MODULE_CODE_LECTURE).withIsRecurring(VALID_RECURRING_LECTURE)
             .withTags(VALID_TAG_LECTURE).build();
 
-    public static final String KEYWORD_MATCHING_MEIER = "Meier"; // A keyword that matches MEIER
+    public static final String KEYWORD_MATCHING_TUTORIAL = "Tutorial"; // A keyword that matches TUTORIAL
 
     private TypicalMeetingEntries() {} // prevents instantiation
 
     /**
-     * Returns an {@code LinkyTime} with all the typical meetingEntries.
+     * Returns an {@code LinkyTime} with all the typical meeting entries.
      */
     public static LinkyTime getTypicalAddressBook() {
         LinkyTime lt = new LinkyTime();

--- a/src/test/java/seedu/address/testutil/TypicalMeetingEntries.java
+++ b/src/test/java/seedu/address/testutil/TypicalMeetingEntries.java
@@ -1,0 +1,91 @@
+package seedu.address.testutil;
+
+import static seedu.address.logic.commands.CommandTestUtil.VALID_DATETIME_LECTURE;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_DATETIME_TUTORIAL;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_MODULE_CODE_LECTURE;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_MODULE_CODE_TUTORIAL;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_NAME_LECTURE;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_NAME_TUTORIAL;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_RECURRING_LECTURE;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_RECURRING_TUTORIAL;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_TAG_LECTURE;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_TAG_TUTORIAL;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_URL_LECTURE;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_URL_TUTORIAL;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import seedu.address.model.LinkyTime;
+import seedu.address.model.meetingentry.MeetingEntry;
+
+/**
+ * A utility class containing a list of {@code Person} objects to be used in tests.
+ */
+public class TypicalMeetingEntries {
+
+    public static final MeetingEntry CS2105 = new MeetingEntryBuilder().withName("Lecture")
+            .withUrl("https://www.zoom.com").withDateTime("Thursday")
+            .withModuleCode("CS2105")
+            .withTags("roger").build();
+    public static final MeetingEntry CS2106 = new MeetingEntryBuilder().withName("Lecture")
+            .withUrl("https://www.zoom.com").withDateTime("Wednesday")
+            .withModuleCode("CS2106")
+            .withTags("colin").build();
+    public static final MeetingEntry CS2030 = new MeetingEntryBuilder().withName("Lecture")
+            .withUrl("https://www.zoom.com").withDateTime("Thursday")
+            .withModuleCode("CS2030")
+            .withTags("ooi").build();
+    public static final MeetingEntry CS2040 = new MeetingEntryBuilder().withName("Lecture")
+            .withUrl("https://www.zoom.com").withDateTime("Monday")
+            .withModuleCode("CS2040")
+            .withTags("CKF").build();
+    public static final MeetingEntry CS2100 = new MeetingEntryBuilder().withName("Lecture")
+            .withUrl("https://www.zoom.com").withDateTime("Tuesday")
+            .withModuleCode("CS2100")
+            .withTags("aaron").build();
+    public static final MeetingEntry CS2107 = new MeetingEntryBuilder().withName("Lecture")
+            .withUrl("https://www.zoom.com").withDateTime("Thursday")
+            .withModuleCode("CS2107")
+            .withTags("sufatrio").build();
+
+    // Manually added
+    public static final MeetingEntry PC1221 = new MeetingEntryBuilder().withName("Lecture")
+            .withUrl("https://www.zoom.com").withDateTime("Friday")
+            .withModuleCode("PC1221")
+            .withTags("proftay").build();
+    public static final MeetingEntry CS1101S = new MeetingEntryBuilder().withName("Lecture")
+            .withUrl("https://www.zoom.com").withDateTime("Thursday")
+            .withModuleCode("CS1101S")
+            .withTags("hartinmenz").build();
+
+    // Manually added - Person's details found in {@code CommandTestUtil}
+    public static final MeetingEntry CS2101 = new MeetingEntryBuilder().withName(VALID_NAME_TUTORIAL)
+            .withUrl(VALID_URL_TUTORIAL).withDateTime(VALID_DATETIME_TUTORIAL)
+            .withModuleCode(VALID_MODULE_CODE_TUTORIAL).withIsRecurring(VALID_RECURRING_TUTORIAL)
+            .withTags(VALID_TAG_TUTORIAL).build();
+    public static final MeetingEntry CS2103 = new MeetingEntryBuilder().withName(VALID_NAME_LECTURE)
+            .withUrl(VALID_URL_LECTURE).withDateTime(VALID_DATETIME_LECTURE)
+            .withModuleCode(VALID_MODULE_CODE_LECTURE).withIsRecurring(VALID_RECURRING_LECTURE)
+            .withTags(VALID_TAG_LECTURE).build();
+
+    public static final String KEYWORD_MATCHING_MEIER = "Meier"; // A keyword that matches MEIER
+
+    private TypicalMeetingEntries() {} // prevents instantiation
+
+    /**
+     * Returns an {@code LinkyTime} with all the typical meetingEntries.
+     */
+    public static LinkyTime getTypicalAddressBook() {
+        LinkyTime lt = new LinkyTime();
+        for (MeetingEntry meetingEntry : getTypicalMeetingEntries()) {
+            lt.addMeetingEntry(meetingEntry);
+        }
+        return lt;
+    }
+
+    public static List<MeetingEntry> getTypicalMeetingEntries() {
+        return new ArrayList<>(Arrays.asList(CS2105, CS2106, CS2030, CS2040, CS2100, CS1101S));
+    }
+}

--- a/src/test/java/seedu/address/testutil/TypicalMeetingEntries.java
+++ b/src/test/java/seedu/address/testutil/TypicalMeetingEntries.java
@@ -72,14 +72,15 @@ public class TypicalMeetingEntries {
 
     public static final String KEYWORD_MATCHING_TUTORIAL = "Tutorial"; // A keyword that matches TUTORIAL
 
-    private TypicalMeetingEntries() {} // prevents instantiation
+    private TypicalMeetingEntries() {
+    } // prevents instantiation
 
     /**
      * Returns an {@code LinkyTime} with all the typical meeting entries.
      */
     public static LinkyTime getTypicalAddressBook() {
-        LinkyTime lt = new LinkyTime();
-        for (MeetingEntry meetingEntry : getTypicalMeetingEntries()) {
+        final LinkyTime lt = new LinkyTime();
+        for (final MeetingEntry meetingEntry : getTypicalMeetingEntries()) {
             lt.addMeetingEntry(meetingEntry);
         }
         return lt;

--- a/src/test/java/seedu/address/testutil/TypicalMeetingEntries.java
+++ b/src/test/java/seedu/address/testutil/TypicalMeetingEntries.java
@@ -24,7 +24,6 @@ import seedu.address.model.meetingentry.MeetingEntry;
  * A utility class containing a list of {@code MeetingEntry} objects to be used in tests.
  */
 public class TypicalMeetingEntries {
-
     public static final MeetingEntry CS2105 = new MeetingEntryBuilder().withName("Lecture")
             .withUrl("https://www.zoom.com").withDateTime("Thursday")
             .withModuleCode("CS2105")
@@ -60,7 +59,7 @@ public class TypicalMeetingEntries {
             .withModuleCode("CS1101S")
             .withTags("hartinmenz").build();
 
-    // Manually added - Person's details found in {@code CommandTestUtil}
+    // Manually added - MeetingEntry's details found in {@code CommandTestUtil}
     public static final MeetingEntry CS2101 = new MeetingEntryBuilder().withName(VALID_NAME_TUTORIAL)
             .withUrl(VALID_URL_TUTORIAL).withDateTime(VALID_DATETIME_TUTORIAL)
             .withModuleCode(VALID_MODULE_CODE_TUTORIAL).withIsRecurring(VALID_RECURRING_TUTORIAL)
@@ -78,7 +77,7 @@ public class TypicalMeetingEntries {
     /**
      * Returns an {@code LinkyTime} with all the typical meeting entries.
      */
-    public static LinkyTime getTypicalAddressBook() {
+    public static LinkyTime getTypicalLinkyTime() {
         final LinkyTime lt = new LinkyTime();
         for (final MeetingEntry meetingEntry : getTypicalMeetingEntries()) {
             lt.addMeetingEntry(meetingEntry);


### PR DESCRIPTION
## Related issues
<!-- Please link to the Github issue(s) this PR resolves (type `#` to autocomplete issue) -->
Closes #33 

## Description
<!-- Describe your changes -->
<!-- If it affects UI, screenshots are highly recommended -->
Added AddCommandParser to parse input which creates an AddCommand object to be executed.
Added the add command option into the switch case in LinkyTimeParser.

## How to test
<!-- List down the steps to test this, if applicable -->
`add n/Lecture u/https://zoom.com d/today m/CS2103 r/Y`
Make sure the URL is fully formed, containing the scheme as well, e.g. https://

## Other information
<!--
This section is optional, you may include things like:
- What is left to be done after this
- Any questions or assistance you may require
-->
Need to remove test cases from AddCommandIntegrationTest once ready to make full transition to LinkyTime.
Implement execute_duplicateMeetingEntry_throwsCommandException() once we are able to retrieve meetinglist.
Implement parse_invalidValue_failure() in AddCommandParserTest once we do further input validation.
