### PR TITLE
Implement retrieval and persistence of meeting entries to/from storage

### DIFF
--- a/src/main/java/seedu/address/MainApp.java
+++ b/src/main/java/seedu/address/MainApp.java
@@ -19,7 +19,6 @@ import seedu.address.model.AddressBook;
 import seedu.address.model.LinkyTime;
 import seedu.address.model.Model;
 import seedu.address.model.ModelManager;
-import seedu.address.model.ReadOnlyAddressBook;
 import seedu.address.model.ReadOnlyLinkyTime;
 import seedu.address.model.ReadOnlyUserPrefs;
 import seedu.address.model.UserPrefs;
@@ -79,34 +78,23 @@ public class MainApp extends Application {
      * or an empty address book will be used instead if errors occur when reading {@code storage}'s address book.
      */
     private Model initModelManager(Storage storage, ReadOnlyUserPrefs userPrefs) {
-        Optional<ReadOnlyLinkyTime> linkyTimeOptional;
         ReadOnlyLinkyTime initialData;
-        Optional<ReadOnlyAddressBook> addressBookOptional;
-        ReadOnlyAddressBook initialAddressBookData;
 
         try {
-            addressBookOptional = storage.readAddressBook();
-            if (!addressBookOptional.isPresent()) {
-                logger.info("Data file not found. Will be starting with a sample AddressBook");
-            }
-            initialAddressBookData = addressBookOptional.orElseGet(SampleDataUtil::getSampleAddressBook);
-
-            linkyTimeOptional = storage.readLinkyTime();
+            final Optional<ReadOnlyLinkyTime> linkyTimeOptional = storage.readLinkyTime();
             if (!linkyTimeOptional.isPresent()) {
                 logger.info("Data file not found. Will be starting with a sample LinkyTime data.");
             }
-            initialData = linkyTimeOptional.get();
+            initialData = linkyTimeOptional.orElseGet(SampleDataUtil::getSampleLinkyTime);
         } catch (DataConversionException e) {
-            logger.warning("Data file not in the correct format. Will be starting with an empty AddressBook");
-            initialAddressBookData = new AddressBook();
+            logger.warning("Data file not in the correct format. Will be starting with an empty LinkyTime");
             initialData = new LinkyTime();
         } catch (IOException e) {
-            logger.warning("Problem while reading from the file. Will be starting with an empty AddressBook");
-            initialAddressBookData = new AddressBook();
+            logger.warning("Problem while reading from the file. Will be starting with an empty LinkyTime");
             initialData = new LinkyTime();
         }
 
-        return new ModelManager(initialAddressBookData, userPrefs, initialData);
+        return new ModelManager(new AddressBook(), userPrefs, initialData);
     }
 
     private void initLogging(Config config) {

--- a/src/main/java/seedu/address/MainApp.java
+++ b/src/main/java/seedu/address/MainApp.java
@@ -73,9 +73,9 @@ public class MainApp extends Application {
     }
 
     /**
-     * Returns a {@code ModelManager} with the data from {@code storage}'s address book and {@code userPrefs}. <br>
-     * The data from the sample address book will be used instead if {@code storage}'s address book is not found,
-     * or an empty address book will be used instead if errors occur when reading {@code storage}'s address book.
+     * Returns a {@code ModelManager} with the data from {@code storage}'s LinkyTime and {@code userPrefs}. <br>
+     * The data from the sample LinkyTime will be used instead if {@code storage}'s LinkyTime is not found,
+     * or an empty LinkyTime will be used instead if errors occur when reading {@code storage}'s LinkyTime.
      */
     private Model initModelManager(Storage storage, ReadOnlyUserPrefs userPrefs) {
         ReadOnlyLinkyTime initialData;

--- a/src/main/java/seedu/address/model/util/SampleDataUtil.java
+++ b/src/main/java/seedu/address/model/util/SampleDataUtil.java
@@ -5,7 +5,15 @@ import java.util.Set;
 import java.util.stream.Collectors;
 
 import seedu.address.model.AddressBook;
+import seedu.address.model.LinkyTime;
 import seedu.address.model.ReadOnlyAddressBook;
+import seedu.address.model.ReadOnlyLinkyTime;
+import seedu.address.model.meetingentry.IsRecurring;
+import seedu.address.model.meetingentry.MeetingDateTime;
+import seedu.address.model.meetingentry.MeetingEntry;
+import seedu.address.model.meetingentry.MeetingName;
+import seedu.address.model.meetingentry.MeetingUrl;
+import seedu.address.model.modulecode.ModuleCode;
 import seedu.address.model.person.Address;
 import seedu.address.model.person.Email;
 import seedu.address.model.person.Name;
@@ -46,6 +54,44 @@ public class SampleDataUtil {
             sampleAb.addPerson(samplePerson);
         }
         return sampleAb;
+    }
+
+    public static MeetingEntry[] getSampleMeetingEntries() {
+        final MeetingUrl dummyMeetingUrl = new MeetingUrl("https://legit-uni.zoom.us/j/344299221?pwd=F3a99221");
+        return new MeetingEntry[] {
+            new MeetingEntry(
+                    new MeetingName("CS2103T Lecture"),
+                    dummyMeetingUrl,
+                    new MeetingDateTime("18mar20223pm"),
+                    new ModuleCode("CS2103T"),
+                    new IsRecurring("Y"),
+                    getTagSet()
+            ),
+            new MeetingEntry(
+                    new MeetingName("CS2101 Tutorial"),
+                    dummyMeetingUrl,
+                    new MeetingDateTime("19mar20222pm"),
+                    new ModuleCode("CS2101"),
+                    new IsRecurring("Y"),
+                    getTagSet("memes")
+            ),
+            new MeetingEntry(
+                    new MeetingName("TokTik Rejection Interview"),
+                    dummyMeetingUrl,
+                    new MeetingDateTime("20mar20221am"),
+                    new ModuleCode("Intern"),
+                    new IsRecurring("N"),
+                    getTagSet("internship", "interview")
+            )
+        };
+    }
+
+    public static ReadOnlyLinkyTime getSampleLinkyTime() {
+        final LinkyTime sampleLinkyTime = new LinkyTime();
+        for (final MeetingEntry sampleMeetingEntry : getSampleMeetingEntries()) {
+            sampleLinkyTime.addMeetingEntry(sampleMeetingEntry);
+        }
+        return sampleLinkyTime;
     }
 
     /**

--- a/src/main/java/seedu/address/model/util/SampleDataUtil.java
+++ b/src/main/java/seedu/address/model/util/SampleDataUtil.java
@@ -4,9 +4,7 @@ import java.util.Arrays;
 import java.util.Set;
 import java.util.stream.Collectors;
 
-import seedu.address.model.AddressBook;
 import seedu.address.model.LinkyTime;
-import seedu.address.model.ReadOnlyAddressBook;
 import seedu.address.model.ReadOnlyLinkyTime;
 import seedu.address.model.meetingentry.IsRecurring;
 import seedu.address.model.meetingentry.MeetingDateTime;
@@ -14,74 +12,37 @@ import seedu.address.model.meetingentry.MeetingEntry;
 import seedu.address.model.meetingentry.MeetingName;
 import seedu.address.model.meetingentry.MeetingUrl;
 import seedu.address.model.modulecode.ModuleCode;
-import seedu.address.model.person.Address;
-import seedu.address.model.person.Email;
-import seedu.address.model.person.Name;
-import seedu.address.model.person.Person;
-import seedu.address.model.person.Phone;
 import seedu.address.model.tag.Tag;
 
 /**
- * Contains utility methods for populating {@code AddressBook} with sample data.
+ * Contains utility methods for populating {@code LinkyTime} with sample data.
  */
 public class SampleDataUtil {
-    public static Person[] getSamplePersons() {
-        return new Person[] {
-            new Person(new Name("Alex Yeoh"), new Phone("87438807"), new Email("alexyeoh@example.com"),
-                new Address("Blk 30 Geylang Street 29, #06-40"),
-                getTagSet("friends")),
-            new Person(new Name("Bernice Yu"), new Phone("99272758"), new Email("berniceyu@example.com"),
-                new Address("Blk 30 Lorong 3 Serangoon Gardens, #07-18"),
-                getTagSet("colleagues", "friends")),
-            new Person(new Name("Charlotte Oliveiro"), new Phone("93210283"), new Email("charlotte@example.com"),
-                new Address("Blk 11 Ang Mo Kio Street 74, #11-04"),
-                getTagSet("neighbours")),
-            new Person(new Name("David Li"), new Phone("91031282"), new Email("lidavid@example.com"),
-                new Address("Blk 436 Serangoon Gardens Street 26, #16-43"),
-                getTagSet("family")),
-            new Person(new Name("Irfan Ibrahim"), new Phone("92492021"), new Email("irfan@example.com"),
-                new Address("Blk 47 Tampines Street 20, #17-35"),
-                getTagSet("classmates")),
-            new Person(new Name("Roy Balakrishnan"), new Phone("92624417"), new Email("royb@example.com"),
-                new Address("Blk 45 Aljunied Street 85, #11-31"),
-                getTagSet("colleagues"))
-        };
-    }
-
-    public static ReadOnlyAddressBook getSampleAddressBook() {
-        AddressBook sampleAb = new AddressBook();
-        for (Person samplePerson : getSamplePersons()) {
-            sampleAb.addPerson(samplePerson);
-        }
-        return sampleAb;
-    }
-
     public static MeetingEntry[] getSampleMeetingEntries() {
-        final MeetingUrl dummyMeetingUrl = new MeetingUrl("https://legit-uni.zoom.us/j/344299221?pwd=F3a99221");
         return new MeetingEntry[] {
             new MeetingEntry(
-                    new MeetingName("CS2103T Lecture"),
-                    dummyMeetingUrl,
-                    new MeetingDateTime("18mar20223pm"),
-                    new ModuleCode("CS2103T"),
-                    new IsRecurring("Y"),
-                    getTagSet()
+                new MeetingName("CS2103T Lecture"),
+                new MeetingUrl("https://legit-uni.zoom.us/j/344299221?pwd=F3a99221"),
+                new MeetingDateTime("18mar20223pm"),
+                new ModuleCode("CS2103T"),
+                new IsRecurring("Y"),
+                getTagSet()
             ),
             new MeetingEntry(
-                    new MeetingName("CS2101 Tutorial"),
-                    dummyMeetingUrl,
-                    new MeetingDateTime("19mar20222pm"),
-                    new ModuleCode("CS2101"),
-                    new IsRecurring("Y"),
-                    getTagSet("memes")
+                new MeetingName("CS2101 Tutorial"),
+                new MeetingUrl("https://meet.google.com/omg-look-ma"),
+                new MeetingDateTime("19mar20222pm"),
+                new ModuleCode("CS2101"),
+                new IsRecurring("Y"),
+                getTagSet("memes")
             ),
             new MeetingEntry(
-                    new MeetingName("TokTik Rejection Interview"),
-                    dummyMeetingUrl,
-                    new MeetingDateTime("20mar20221am"),
-                    new ModuleCode("Intern"),
-                    new IsRecurring("N"),
-                    getTagSet("internship", "interview")
+                new MeetingName("TokTik Rejection Interview"),
+                new MeetingUrl("https://www.youtube.com/watch?v=dQw4w9WgXcQ"),
+                new MeetingDateTime("20mar20221am"),
+                new ModuleCode("Intern"),
+                new IsRecurring("N"),
+                getTagSet("internship", "interview")
             )
         };
     }
@@ -102,5 +63,4 @@ public class SampleDataUtil {
                 .map(Tag::new)
                 .collect(Collectors.toSet());
     }
-
 }

--- a/src/main/java/seedu/address/storage/JsonAdaptedMeetingEntry.java
+++ b/src/main/java/seedu/address/storage/JsonAdaptedMeetingEntry.java
@@ -1,0 +1,129 @@
+package seedu.address.storage;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import seedu.address.commons.exceptions.IllegalValueException;
+import seedu.address.model.meetingentry.IsRecurring;
+import seedu.address.model.meetingentry.MeetingDateTime;
+import seedu.address.model.meetingentry.MeetingEntry;
+import seedu.address.model.meetingentry.MeetingName;
+import seedu.address.model.meetingentry.MeetingUrl;
+import seedu.address.model.modulecode.ModuleCode;
+import seedu.address.model.tag.Tag;
+
+/**
+ * Jackson-friendly version of {@link MeetingEntry}.
+ */
+class JsonAdaptedMeetingEntry {
+    public static final String MISSING_FIELD_MESSAGE_FORMAT = "Meeting Entry's %s field is missing!";
+
+    private final String name;
+    private final String url;
+    private final String dateTime;
+    private final String moduleCode;
+    private final String isRecurring;
+    private final List<JsonAdaptedTag> tagged = new ArrayList<>();
+
+    /**
+     * Constructs a {@code JsonAdaptedMeetingEntry} with the given meeting entry details.
+     */
+    @JsonCreator
+    public JsonAdaptedMeetingEntry(@JsonProperty("name") String name,
+                                   @JsonProperty("url") String url,
+                                   @JsonProperty("dateTime") String dateTime,
+                                   @JsonProperty("moduleCode") String moduleCode,
+                                   @JsonProperty("isRecurring") String isRecurring,
+                                   @JsonProperty("tagged") List<JsonAdaptedTag> tagged) {
+        this.name = name;
+        this.url = url;
+        this.dateTime = dateTime;
+        this.moduleCode = moduleCode;
+        this.isRecurring = isRecurring;
+        if (tagged != null) {
+            this.tagged.addAll(tagged);
+        }
+    }
+
+    /**
+     * Converts a given {@code MeetingEntry} into this class for Jackson use.
+     */
+    public JsonAdaptedMeetingEntry(MeetingEntry source) {
+        name = source.getName().name;
+        url = source.getUrl().meetingUrl.toExternalForm();
+        dateTime = source.getDateTime().datetime;
+        moduleCode = source.getModuleCode().moduleCode;
+        isRecurring = source.getIsRecurring().toString();
+        tagged.addAll(source.getTags().stream()
+                .map(JsonAdaptedTag::new)
+                .collect(Collectors.toList()));
+    }
+
+    /**
+     * Converts this Jackson-friendly adapted meeting entry object into the model's {@code MeetingEntry} object.
+     *
+     * @throws IllegalValueException if there were any data constraints violated in the adapted meeting entry.
+     */
+    public MeetingEntry toModelType() throws IllegalValueException {
+        final List<Tag> meetingEntryTags = new ArrayList<>();
+        for (JsonAdaptedTag tag : tagged) {
+            meetingEntryTags.add(tag.toModelType());
+        }
+
+        if (name == null) {
+            throw new IllegalValueException(String.format(MISSING_FIELD_MESSAGE_FORMAT,
+                    MeetingName.class.getSimpleName()));
+        }
+        if (!MeetingName.isValidName(name)) {
+            throw new IllegalValueException(MeetingName.MESSAGE_CONSTRAINTS);
+        }
+        final MeetingName modelName = new MeetingName(name);
+
+        if (url == null) {
+            throw new IllegalValueException(String.format(MISSING_FIELD_MESSAGE_FORMAT,
+                    MeetingUrl.class.getSimpleName()));
+        }
+        if (!MeetingUrl.isValidUrl(url)) {
+            throw new IllegalValueException(MeetingUrl.MESSAGE_CONSTRAINTS);
+        }
+        final MeetingUrl modelUrl = new MeetingUrl(url);
+
+        if (dateTime == null) {
+            throw new IllegalValueException(String.format(MISSING_FIELD_MESSAGE_FORMAT,
+                    MeetingDateTime.class.getSimpleName()));
+        }
+        // TODO: To be uncommented when MeetingDateTime validation is implemented.
+        // if (!dateTime.isValidDateTime(dateTime)) {
+        //     throw new IllegalValueException(MeetingDateTime.MESSAGE_CONSTRAINTS);
+        // }
+        final MeetingDateTime modelDateTime = new MeetingDateTime(dateTime);
+
+        if (moduleCode == null) {
+            throw new IllegalValueException(String.format(MISSING_FIELD_MESSAGE_FORMAT,
+                    ModuleCode.class.getSimpleName()));
+        }
+        // TODO: To be uncommented when ModuleCode validation is implemented.
+        // if (!moduleCode.isValidModuleCode(moduleCode)) {
+        //     throw new IllegalValueException(ModuleCode.MESSAGE_CONSTRAINTS);
+        // }
+        final ModuleCode modelModuleCode = new ModuleCode(moduleCode);
+
+        if (isRecurring == null) {
+            throw new IllegalValueException(String.format(MISSING_FIELD_MESSAGE_FORMAT,
+                    IsRecurring.class.getSimpleName()));
+        }
+        if (!IsRecurring.isValidRecurringStatus(isRecurring)) {
+            throw new IllegalValueException(IsRecurring.MESSAGE_CONSTRAINTS);
+        }
+        final IsRecurring modelIsRecurring = new IsRecurring(isRecurring);
+
+        final Set<Tag> modelTags = new HashSet<>(meetingEntryTags);
+        return new MeetingEntry(modelName, modelUrl, modelDateTime, modelModuleCode, modelIsRecurring, modelTags);
+    }
+}

--- a/src/main/java/seedu/address/storage/JsonAdaptedMeetingEntry.java
+++ b/src/main/java/seedu/address/storage/JsonAdaptedMeetingEntry.java
@@ -22,7 +22,7 @@ import seedu.address.model.tag.Tag;
  * Jackson-friendly version of {@link MeetingEntry}.
  */
 class JsonAdaptedMeetingEntry {
-    public static final String MISSING_FIELD_MESSAGE_FORMAT = "Meeting Entry's %s field is missing!";
+    public static final String MISSING_FIELD_MESSAGE_FORMAT = "Meeting entry's %s field is missing!";
 
     private final String name;
     private final String url;
@@ -76,6 +76,7 @@ class JsonAdaptedMeetingEntry {
             meetingEntryTags.add(tag.toModelType());
         }
 
+        // Validate name.
         if (name == null) {
             throw new IllegalValueException(String.format(MISSING_FIELD_MESSAGE_FORMAT,
                     MeetingName.class.getSimpleName()));
@@ -85,6 +86,7 @@ class JsonAdaptedMeetingEntry {
         }
         final MeetingName modelName = new MeetingName(name);
 
+        // Validate url.
         if (url == null) {
             throw new IllegalValueException(String.format(MISSING_FIELD_MESSAGE_FORMAT,
                     MeetingUrl.class.getSimpleName()));
@@ -94,26 +96,27 @@ class JsonAdaptedMeetingEntry {
         }
         final MeetingUrl modelUrl = new MeetingUrl(url);
 
+        // Validate dateTime.
         if (dateTime == null) {
             throw new IllegalValueException(String.format(MISSING_FIELD_MESSAGE_FORMAT,
                     MeetingDateTime.class.getSimpleName()));
         }
-        // TODO: To be uncommented when MeetingDateTime validation is implemented.
-        // if (!dateTime.isValidDateTime(dateTime)) {
-        //     throw new IllegalValueException(MeetingDateTime.MESSAGE_CONSTRAINTS);
-        // }
+        if (!MeetingDateTime.isValidDateTime(dateTime)) {
+            throw new IllegalValueException(MeetingDateTime.MESSAGE_CONSTRAINTS);
+        }
         final MeetingDateTime modelDateTime = new MeetingDateTime(dateTime);
 
+        // Validate module code.
         if (moduleCode == null) {
             throw new IllegalValueException(String.format(MISSING_FIELD_MESSAGE_FORMAT,
                     ModuleCode.class.getSimpleName()));
         }
-        // TODO: To be uncommented when ModuleCode validation is implemented.
-        // if (!moduleCode.isValidModuleCode(moduleCode)) {
-        //     throw new IllegalValueException(ModuleCode.MESSAGE_CONSTRAINTS);
-        // }
+        if (!ModuleCode.isValidModuleCode(moduleCode)) {
+            throw new IllegalValueException(ModuleCode.MESSAGE_CONSTRAINTS);
+        }
         final ModuleCode modelModuleCode = new ModuleCode(moduleCode);
 
+        // Validate recurring status.
         if (isRecurring == null) {
             throw new IllegalValueException(String.format(MISSING_FIELD_MESSAGE_FORMAT,
                     IsRecurring.class.getSimpleName()));

--- a/src/main/java/seedu/address/storage/JsonSerializableLinkyTime.java
+++ b/src/main/java/seedu/address/storage/JsonSerializableLinkyTime.java
@@ -1,0 +1,61 @@
+package seedu.address.storage;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonRootName;
+
+import seedu.address.commons.exceptions.IllegalValueException;
+import seedu.address.model.LinkyTime;
+import seedu.address.model.ReadOnlyLinkyTime;
+import seedu.address.model.meetingentry.MeetingEntry;
+
+/**
+ * An immutable LinkyTime that is serializable to JSON format.
+ */
+@JsonRootName(value = "linkytime")
+class JsonSerializableLinkyTime {
+    public static final String MESSAGE_DUPLICATE_MEETING_ENTRY =
+            "Meeting entries list contains duplicate meeting entry(s).";
+
+    private final List<JsonAdaptedMeetingEntry> meetingEntries = new ArrayList<>();
+
+    /**
+     * Constructs a {@code JsonSerializableLinkyTime} with the given meeting entries.
+     */
+    @JsonCreator
+    public JsonSerializableLinkyTime(@JsonProperty("meetingEntries") List<JsonAdaptedMeetingEntry> meetingEntries) {
+        this.meetingEntries.addAll(meetingEntries);
+    }
+
+    /**
+     * Converts a given {@code ReadOnlyLinkyTime} into this class for Jackson use.
+     *
+     * @param source future changes to this will not affect the created {@code JsonSerializableLinkyTime}.
+     */
+    public JsonSerializableLinkyTime(ReadOnlyLinkyTime source) {
+        meetingEntries.addAll(
+                source.getMeetingEntryList().stream().map(JsonAdaptedMeetingEntry::new).collect(Collectors.toList()));
+    }
+
+    /**
+     * Converts this LinkyTime into the model's {@code LinkyTime} object.
+     *
+     * @throws IllegalValueException if there were any data constraints violated.
+     */
+    public LinkyTime toModelType() throws IllegalValueException {
+        final LinkyTime linkyTime = new LinkyTime();
+        for (final JsonAdaptedMeetingEntry jsonAdaptedMeetingEntry : meetingEntries) {
+            final MeetingEntry meetingEntry = jsonAdaptedMeetingEntry.toModelType();
+            if (linkyTime.hasMeetingEntry(meetingEntry)) {
+                throw new IllegalValueException(MESSAGE_DUPLICATE_MEETING_ENTRY);
+            }
+            linkyTime.addMeetingEntry(meetingEntry);
+        }
+        return linkyTime;
+    }
+
+}


### PR DESCRIPTION
## Related issues
<!-- Please link to the Github issue(s) this PR resolves (type `#` to autocomplete issue) -->
Fixes #37.
## Description
<!-- Describe your changes -->
<!-- If it affects UI, screenshots are highly recommended -->
1. Populate initial list with sample meeting entries if no data file is found.
2. Support serialization/deserialization of meeting entries to/from JSON.
3. Meeting entries are now retrieved from or persisted to storage.
## How to test
<!-- List down the steps to test this, if applicable -->
### Viewing of sample data
1. Delete the original data file from `data/app.json`.
2. Run the program, you should now see three sample meeting entries.

### Updating of meeting entries
1. Start the program.
2. Use the `add` command to add a new meeting entry to your existing list.
3. You should now see your new meeting entry in your list.
4. Exit the program.
5. Start the program again.
6. You should still see the meeting entry that you've added earlier in your list.
## Other information
<!--
This section is optional, you may include things like:
- What is left to be done after this
- Any questions or assistance you may require
-->
Test cases are not written at the moment. Currently waiting for `MeetingEntry` to be fully implemented.