### PR TITLE
Implement ModuleCode GUI List

### DIFF
--- a/src/main/java/seedu/address/logic/Logic.java
+++ b/src/main/java/seedu/address/logic/Logic.java
@@ -9,6 +9,7 @@ import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.logic.parser.exceptions.ParseException;
 import seedu.address.model.ReadOnlyLinkyTime;
 import seedu.address.model.meetingentry.MeetingEntry;
+import seedu.address.model.modulecode.ModuleCode;
 
 /**
  * API of the Logic component
@@ -32,6 +33,9 @@ public interface Logic {
 
     /** Returns an unmodifiable view of the filtered list of meeting entries */
     ObservableList<MeetingEntry> getFilteredMeetingEntryList();
+
+    /** Returns an unmodifiable view of the filtered list of module codes */
+    ObservableList<ModuleCode> getFilteredModuleCodeList();
 
     /**
      * Returns the user prefs' LinkyTime file path.

--- a/src/main/java/seedu/address/logic/LogicManager.java
+++ b/src/main/java/seedu/address/logic/LogicManager.java
@@ -15,6 +15,7 @@ import seedu.address.logic.parser.exceptions.ParseException;
 import seedu.address.model.Model;
 import seedu.address.model.ReadOnlyLinkyTime;
 import seedu.address.model.meetingentry.MeetingEntry;
+import seedu.address.model.modulecode.ModuleCode;
 import seedu.address.storage.Storage;
 
 /**
@@ -62,6 +63,11 @@ public class LogicManager implements Logic {
     @Override
     public ObservableList<MeetingEntry> getFilteredMeetingEntryList() {
         return model.getFilteredMeetingEntryList();
+    }
+
+    @Override
+    public ObservableList<ModuleCode> getFilteredModuleCodeList() {
+        return model.getFilteredModuleCodeList();
     }
 
     @Override

--- a/src/main/java/seedu/address/logic/commands/modulecode/ListModuleCodeCommand.java
+++ b/src/main/java/seedu/address/logic/commands/modulecode/ListModuleCodeCommand.java
@@ -1,0 +1,25 @@
+package seedu.address.logic.commands.modulecode;
+
+import static java.util.Objects.requireNonNull;
+import static seedu.address.model.Model.PREDICATE_SHOW_ALL_MODULE_CODES;
+
+import seedu.address.logic.commands.Command;
+import seedu.address.logic.commands.CommandResult;
+import seedu.address.model.Model;
+
+/**
+ * Lists all module codes in the LinkyTime module code list to the user.
+ */
+public class ListModuleCodeCommand extends Command {
+
+    public static final String COMMAND_WORD = "mlist";
+
+    public static final String MESSAGE_SUCCESS = "Listed all module codes";
+
+    @Override
+    public CommandResult execute(Model model) {
+        requireNonNull(model);
+        model.updateFilteredModuleCodeList(PREDICATE_SHOW_ALL_MODULE_CODES);
+        return new CommandResult(MESSAGE_SUCCESS);
+    }
+}

--- a/src/main/java/seedu/address/logic/commands/modulecode/ListModuleCodeCommand.java
+++ b/src/main/java/seedu/address/logic/commands/modulecode/ListModuleCodeCommand.java
@@ -11,7 +11,6 @@ import seedu.address.model.Model;
  * Lists all module codes in the LinkyTime module code list to the user.
  */
 public class ListModuleCodeCommand extends Command {
-
     public static final String COMMAND_WORD = "mlist";
 
     public static final String MESSAGE_SUCCESS = "Listed all module codes";

--- a/src/main/java/seedu/address/logic/parser/LinkyTimeParser.java
+++ b/src/main/java/seedu/address/logic/parser/LinkyTimeParser.java
@@ -6,12 +6,14 @@ import static seedu.address.commons.core.Messages.MESSAGE_UNKNOWN_COMMAND;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
+import seedu.address.logic.commands.ClearCommand;
 import seedu.address.logic.commands.Command;
 import seedu.address.logic.commands.ExitCommand;
 import seedu.address.logic.commands.HelpCommand;
 import seedu.address.logic.commands.meetingentry.AddCommand;
 import seedu.address.logic.commands.meetingentry.DeleteCommand;
 import seedu.address.logic.commands.meetingentry.ListCommand;
+import seedu.address.logic.commands.modulecode.ListModuleCodeCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
 import seedu.address.logic.parser.meetingentry.AddCommandParser;
 import seedu.address.logic.parser.meetingentry.DeleteCommandParser;
@@ -43,12 +45,23 @@ public class LinkyTimeParser {
         final String arguments = matcher.group("arguments");
 
         switch (commandWord) {
+        // MeetingEntry Commands
         case AddCommand.COMMAND_WORD:
             return new AddCommandParser().parse(arguments);
         case DeleteCommand.COMMAND_WORD:
             return new DeleteCommandParser().parse(arguments);
         case ListCommand.COMMAND_WORD:
             return new ListCommand();
+
+        // ModuleCode Commands
+        case ListModuleCodeCommand.COMMAND_WORD:
+            return new ListModuleCodeCommand();
+
+        // System Commands
+        case ClearCommand.COMMAND_WORD:
+            return new ClearCommand();
+        case HelpCommand.COMMAND_WORD:
+            return new HelpCommand();
         case ExitCommand.COMMAND_WORD:
             return new ExitCommand();
         default:

--- a/src/main/java/seedu/address/model/LinkyTime.java
+++ b/src/main/java/seedu/address/model/LinkyTime.java
@@ -3,10 +3,13 @@ package seedu.address.model;
 import static java.util.Objects.requireNonNull;
 
 import java.util.List;
+import java.util.Objects;
 
 import javafx.collections.ObservableList;
 import seedu.address.model.meetingentry.MeetingEntry;
 import seedu.address.model.meetingentry.UniqueMeetingEntryList;
+import seedu.address.model.modulecode.ModuleCode;
+import seedu.address.model.modulecode.UniqueModuleCodeList;
 
 /**
  * Wraps all data of LinkyTime
@@ -15,6 +18,7 @@ import seedu.address.model.meetingentry.UniqueMeetingEntryList;
 public class LinkyTime implements ReadOnlyLinkyTime {
 
     private final UniqueMeetingEntryList meetingEntries;
+    private final UniqueModuleCodeList moduleCodes;
 
     /*
      * The 'unusual' code block below is a non-static initialization block, sometimes used to avoid duplication
@@ -25,6 +29,7 @@ public class LinkyTime implements ReadOnlyLinkyTime {
      */
     {
         meetingEntries = new UniqueMeetingEntryList();
+        moduleCodes = new UniqueModuleCodeList();
     }
 
     public LinkyTime() {}
@@ -48,12 +53,21 @@ public class LinkyTime implements ReadOnlyLinkyTime {
     }
 
     /**
+     * Replaces the contents of the module code list with {@code moduleCodes}.
+     * {@code moduleCodes} must not contain duplicate module codes.
+     */
+    public void setModuleCodes(List<ModuleCode> moduleCodes) {
+        this.moduleCodes.setModuleCodes(moduleCodes);
+    }
+
+    /**
      * Resets the existing data of this {@code LinkyTime} with {@code newData}.
      */
     public void resetData(ReadOnlyLinkyTime newData) {
         requireNonNull(newData);
 
         setMeetingEntries(newData.getMeetingEntryList());
+        setModuleCodes(newData.getModuleCodeList());
     }
 
     //// meeting-entry-level operations
@@ -92,11 +106,30 @@ public class LinkyTime implements ReadOnlyLinkyTime {
         meetingEntries.remove(key);
     }
 
+    //// module-code-level operations
+
+    /**
+     * Returns true if a module code that is identical to {@code moduleCode} exists in LinkyTime.
+     */
+    public boolean hasModuleCode(ModuleCode moduleCode) {
+        requireNonNull(moduleCode);
+        return moduleCodes.contains(moduleCode);
+    }
+
+    /**
+     * Adds a module code to LinkyTime.
+     * The module code must not already exist in LinkyTime.
+     */
+    public void addModuleCode(ModuleCode moduleCode) {
+        moduleCodes.add(moduleCode);
+    }
+
     //// util methods
 
     @Override
     public String toString() {
-        return meetingEntries.asUnmodifiableObservableList().size() + " meeting entries";
+        return meetingEntries.asUnmodifiableObservableList().size() + " meeting entries\n"
+                + moduleCodes.asUnmodifiableObservableList().size() + " modules";
         // TODO: refine later
     }
 
@@ -106,14 +139,20 @@ public class LinkyTime implements ReadOnlyLinkyTime {
     }
 
     @Override
+    public ObservableList<ModuleCode> getModuleCodeList() {
+        return moduleCodes.asUnmodifiableObservableList();
+    }
+
+    @Override
     public boolean equals(Object other) {
         return other == this // short circuit if same object
                 || (other instanceof LinkyTime // instanceof handles nulls
-                && meetingEntries.equals(((LinkyTime) other).meetingEntries));
+                && meetingEntries.equals(((LinkyTime) other).meetingEntries)
+                && moduleCodes.equals(((LinkyTime) other).moduleCodes));
     }
 
     @Override
     public int hashCode() {
-        return meetingEntries.hashCode();
+        return Objects.hash(meetingEntries, moduleCodes);
     }
 }

--- a/src/main/java/seedu/address/model/Model.java
+++ b/src/main/java/seedu/address/model/Model.java
@@ -6,6 +6,7 @@ import java.util.function.Predicate;
 import javafx.collections.ObservableList;
 import seedu.address.commons.core.GuiSettings;
 import seedu.address.model.meetingentry.MeetingEntry;
+import seedu.address.model.modulecode.ModuleCode;
 
 /**
  * The API of the Model component.
@@ -13,6 +14,9 @@ import seedu.address.model.meetingentry.MeetingEntry;
 public interface Model extends AddressBookModel {
     /** {@code Predicate} that always evaluate to true */
     Predicate<MeetingEntry> PREDICATE_SHOW_ALL_MEETING_ENTRIES = unused -> true;
+    Predicate<ModuleCode> PREDICATE_SHOW_ALL_MODULE_CODES = unused -> true;
+
+    // =========== UserPrefs ===============================================================================
 
     /**
      * Replaces user prefs data with the data in {@code userPrefs}.
@@ -44,6 +48,8 @@ public interface Model extends AddressBookModel {
      */
     void setLinkyTimeFilePath(Path linkyTimeFilePath);
 
+    // =========== LinkyTime ===============================================================================
+
     /**
      * Replaces LinkyTime data with the data in {@code linkyTime}.
      */
@@ -51,6 +57,8 @@ public interface Model extends AddressBookModel {
 
     /** Returns LinkyTime */
     ReadOnlyLinkyTime getLinkyTime();
+
+    // =========== MeetingEntry ============================================================================
 
     /**
      * Returns true if a meeting entry that is identical to {@code meetingEntry} exists in LinkyTime.
@@ -75,6 +83,8 @@ public interface Model extends AddressBookModel {
      */
     void setMeetingEntry(MeetingEntry target, MeetingEntry editedMeetingEntry);
 
+    // =========== Filtered MeetingEntry List Accessors ====================================================
+
     /** Returns an unmodifiable view of the filtered meeting entry list */
     ObservableList<MeetingEntry> getFilteredMeetingEntryList();
 
@@ -83,4 +93,22 @@ public interface Model extends AddressBookModel {
      * @throws NullPointerException if {@code predicate} is null.
      */
     void updateFilteredMeetingEntryList(Predicate<MeetingEntry> predicate);
+
+    // =========== ModuleCode ==============================================================================
+
+    /**
+     * Returns true if a module code that is identical to {@code moduleCode} exists in LinkyTime.
+     */
+    boolean hasModuleCode(ModuleCode moduleCode);
+
+    // =========== Filtered ModuleCode List Accessors ======================================================
+
+    /** Returns an unmodifiable view of the filtered module code list */
+    ObservableList<ModuleCode> getFilteredModuleCodeList();
+
+    /**
+     * Updates the filter of the filtered module code list to filter by the given {@code predicate}.
+     * @throws NullPointerException if {@code predicate} is null.
+     */
+    void updateFilteredModuleCodeList(Predicate<ModuleCode> predicate);
 }

--- a/src/main/java/seedu/address/model/ModelManager.java
+++ b/src/main/java/seedu/address/model/ModelManager.java
@@ -12,6 +12,7 @@ import javafx.collections.transformation.FilteredList;
 import seedu.address.commons.core.GuiSettings;
 import seedu.address.commons.core.LogsCenter;
 import seedu.address.model.meetingentry.MeetingEntry;
+import seedu.address.model.modulecode.ModuleCode;
 
 /**
  * Represents the in-memory model of the LinkyTime data.
@@ -22,6 +23,7 @@ public class ModelManager extends AddressBookModelManager implements Model {
     private final LinkyTime linkyTime;
     private final UserPrefs userPrefs;
     private final FilteredList<MeetingEntry> filteredMeetingEntries;
+    private final FilteredList<ModuleCode> filteredModuleCodes;
 
     /**
      * Initializes a ModelManager with the given addressBook and userPrefs.
@@ -35,13 +37,14 @@ public class ModelManager extends AddressBookModelManager implements Model {
         this.linkyTime = new LinkyTime(linkyTime);
         this.userPrefs = new UserPrefs(userPrefs);
         filteredMeetingEntries = new FilteredList<>(this.linkyTime.getMeetingEntryList());
+        filteredModuleCodes = new FilteredList<>(this.linkyTime.getModuleCodeList());
     }
 
     public ModelManager() {
         this(new AddressBook(), new UserPrefs(), new LinkyTime());
     }
 
-    //=========== UserPrefs ==================================================================================
+    // =========== UserPrefs ===============================================================================
 
     @Override
     public void setUserPrefs(ReadOnlyUserPrefs userPrefs) {
@@ -76,7 +79,7 @@ public class ModelManager extends AddressBookModelManager implements Model {
         userPrefs.setAddressBookFilePath(addressBookFilePath);
     }
 
-    //=========== LinkyTime ================================================================================
+    // =========== LinkyTime ===============================================================================
 
     @Override
     public void setLinkyTime(ReadOnlyLinkyTime linkyTime) {
@@ -87,6 +90,8 @@ public class ModelManager extends AddressBookModelManager implements Model {
     public ReadOnlyLinkyTime getLinkyTime() {
         return linkyTime;
     }
+
+    // =========== MeetingEntry ============================================================================
 
     @Override
     public boolean hasMeetingEntry(MeetingEntry meetingEntry) {
@@ -112,12 +117,8 @@ public class ModelManager extends AddressBookModelManager implements Model {
         linkyTime.setMeetingEntry(target, editedMeetingEntry);
     }
 
-    //=========== Filtered Person List Accessors =============================================================
+    // =========== Filtered MeetingEntry List Accessors ====================================================
 
-    /**
-     * Returns an unmodifiable view of the list of {@code Person} backed by the internal list of
-     * {@code versionedAddressBook}
-     */
     @Override
     public ObservableList<MeetingEntry> getFilteredMeetingEntryList() {
         return filteredMeetingEntries;
@@ -127,6 +128,27 @@ public class ModelManager extends AddressBookModelManager implements Model {
     public void updateFilteredMeetingEntryList(Predicate<MeetingEntry> predicate) {
         requireNonNull(predicate);
         filteredMeetingEntries.setPredicate(predicate);
+    }
+
+    // =========== ModuleCode ==============================================================================
+
+    @Override
+    public boolean hasModuleCode(ModuleCode moduleCode) {
+        requireNonNull(moduleCode);
+        return linkyTime.hasModuleCode(moduleCode);
+    }
+
+    // =========== Filtered ModuleCode List Accessors ======================================================
+
+    @Override
+    public ObservableList<ModuleCode> getFilteredModuleCodeList() {
+        return filteredModuleCodes;
+    }
+
+    @Override
+    public void updateFilteredModuleCodeList(Predicate<ModuleCode> predicate) {
+        requireNonNull(predicate);
+        filteredModuleCodes.setPredicate(predicate);
     }
 
     @Override
@@ -145,7 +167,8 @@ public class ModelManager extends AddressBookModelManager implements Model {
         final ModelManager other = (ModelManager) obj;
         return super.equals(other)
                 && userPrefs.equals(other.userPrefs)
-                && filteredMeetingEntries.equals(other.filteredMeetingEntries);
+                && filteredMeetingEntries.equals(other.filteredMeetingEntries)
+                && filteredModuleCodes.equals(other.filteredModuleCodes);
     }
 
 }

--- a/src/main/java/seedu/address/model/ReadOnlyLinkyTime.java
+++ b/src/main/java/seedu/address/model/ReadOnlyLinkyTime.java
@@ -2,6 +2,7 @@ package seedu.address.model;
 
 import javafx.collections.ObservableList;
 import seedu.address.model.meetingentry.MeetingEntry;
+import seedu.address.model.modulecode.ModuleCode;
 
 /**
  * Unmodifiable view of LinkyTime data
@@ -14,4 +15,9 @@ public interface ReadOnlyLinkyTime {
      */
     ObservableList<MeetingEntry> getMeetingEntryList();
 
+    /**
+     * Returns an unmodifiable view of the module code list.
+     * This list will not contain any duplicate module codes.
+     */
+    ObservableList<ModuleCode> getModuleCodeList();
 }

--- a/src/main/java/seedu/address/model/meetingentry/MeetingEntryContainsKeywordsPredicate.java
+++ b/src/main/java/seedu/address/model/meetingentry/MeetingEntryContainsKeywordsPredicate.java
@@ -25,7 +25,7 @@ public class MeetingEntryContainsKeywordsPredicate implements Predicate<MeetingE
     public boolean test(MeetingEntry meetingEntry) {
         return keywords.stream()
                 .anyMatch(keyword -> meetingEntry.getName().name.toLowerCase().contains(keyword.toLowerCase())
-                        || meetingEntry.getModuleCode().moduleCode.toLowerCase().contains(keyword.toLowerCase())
+                        || meetingEntry.getModuleCode().code.toLowerCase().contains(keyword.toLowerCase())
                         || meetingEntry.getTags().stream()
                         .anyMatch(tag -> tag.tagName.toLowerCase().contains(keyword.toLowerCase())));
     }

--- a/src/main/java/seedu/address/model/modulecode/ModuleCode.java
+++ b/src/main/java/seedu/address/model/modulecode/ModuleCode.java
@@ -18,17 +18,21 @@ public class ModuleCode {
      */
     public static final String VALIDATION_REGEX = "[\\p{Alnum}][\\p{Alnum} ]*";
 
-    public final String moduleCode;
+    public final String code;
 
     /**
      * Constructs a {@code ModuleCode}.
      *
-     * @param moduleCode A valid module code.
+     * @param code A valid module code.
      */
-    public ModuleCode(String moduleCode) {
-        requireNonNull(moduleCode);
-        checkArgument(isValidModuleCode(moduleCode), MESSAGE_CONSTRAINTS);
-        this.moduleCode = moduleCode;
+    public ModuleCode(String code) {
+        requireNonNull(code);
+        checkArgument(isValidModuleCode(code), MESSAGE_CONSTRAINTS);
+        this.code = code;
+    }
+
+    public String getCode() {
+        return code;
     }
 
     /**
@@ -44,19 +48,19 @@ public class ModuleCode {
 
     @Override
     public String toString() {
-        return '[' + moduleCode + ']';
+        return '[' + code + ']';
     }
 
     @Override
     public boolean equals(Object other) {
         return other == this // short circuit if same object
                 || (other instanceof ModuleCode // instanceof handles nulls
-                && moduleCode.equals(((ModuleCode) other).moduleCode)); // state check
+                && code.equals(((ModuleCode) other).code)); // state check
     }
 
     @Override
     public int hashCode() {
-        return moduleCode.hashCode();
+        return code.hashCode();
     }
 
 }

--- a/src/main/java/seedu/address/model/util/SampleDataUtil.java
+++ b/src/main/java/seedu/address/model/util/SampleDataUtil.java
@@ -47,10 +47,17 @@ public class SampleDataUtil {
         };
     }
 
+    public static ModuleCode[] getSampleModuleCodes() {
+        return new ModuleCode[] { new ModuleCode("CS2103T"), new ModuleCode("CS2101"), new ModuleCode("Intern") };
+    }
+
     public static ReadOnlyLinkyTime getSampleLinkyTime() {
         final LinkyTime sampleLinkyTime = new LinkyTime();
         for (final MeetingEntry sampleMeetingEntry : getSampleMeetingEntries()) {
             sampleLinkyTime.addMeetingEntry(sampleMeetingEntry);
+        }
+        for (final ModuleCode sampleModuleCode : getSampleModuleCodes()) {
+            sampleLinkyTime.addModuleCode(sampleModuleCode);
         }
         return sampleLinkyTime;
     }

--- a/src/main/java/seedu/address/storage/JsonAdaptedMeetingEntry.java
+++ b/src/main/java/seedu/address/storage/JsonAdaptedMeetingEntry.java
@@ -58,7 +58,7 @@ class JsonAdaptedMeetingEntry {
         name = source.getName().name;
         url = source.getUrl().meetingUrl.toExternalForm();
         dateTime = source.getDateTime().datetime;
-        moduleCode = source.getModuleCode().moduleCode;
+        moduleCode = source.getModuleCode().code;
         isRecurring = source.getIsRecurring().toString();
         tagged.addAll(source.getTags().stream()
                 .map(JsonAdaptedTag::new)

--- a/src/main/java/seedu/address/storage/JsonAdaptedModuleCode.java
+++ b/src/main/java/seedu/address/storage/JsonAdaptedModuleCode.java
@@ -1,0 +1,49 @@
+package seedu.address.storage;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import seedu.address.commons.exceptions.IllegalValueException;
+import seedu.address.model.modulecode.ModuleCode;
+
+/**
+ * Jackson-friendly version of {@link ModuleCode}.
+ */
+class JsonAdaptedModuleCode {
+    public static final String MISSING_FIELD_MESSAGE_FORMAT = "Module code's %s field is missing!";
+
+    private final String code;
+
+    /**
+     * Constructs a {@code JsonAdaptedModuleCode} with the given module code details.
+     */
+    @JsonCreator
+    public JsonAdaptedModuleCode(@JsonProperty("code") String code) {
+        this.code = code;
+    }
+
+    /**
+     * Converts a given {@code ModuleCode} into this class for Jackson use.
+     */
+    public JsonAdaptedModuleCode(ModuleCode source) {
+        code = source.getCode();
+    }
+
+    /**
+     * Converts this Jackson-friendly adapted module code object into the model's {@code ModuleCode} object.
+     *
+     * @throws IllegalValueException if there were any data constraints violated in the adapted module code.
+     */
+    public ModuleCode toModelType() throws IllegalValueException {
+        // Validate name.
+        if (code == null) {
+            throw new IllegalValueException(String.format(MISSING_FIELD_MESSAGE_FORMAT,
+                    ModuleCode.class.getSimpleName()));
+        }
+        if (!ModuleCode.isValidModuleCode(code)) {
+            throw new IllegalValueException(ModuleCode.MESSAGE_CONSTRAINTS);
+        }
+
+        return new ModuleCode(code);
+    }
+}

--- a/src/main/java/seedu/address/storage/JsonSerializableLinkyTime.java
+++ b/src/main/java/seedu/address/storage/JsonSerializableLinkyTime.java
@@ -12,6 +12,7 @@ import seedu.address.commons.exceptions.IllegalValueException;
 import seedu.address.model.LinkyTime;
 import seedu.address.model.ReadOnlyLinkyTime;
 import seedu.address.model.meetingentry.MeetingEntry;
+import seedu.address.model.modulecode.ModuleCode;
 
 /**
  * An immutable LinkyTime that is serializable to JSON format.
@@ -20,15 +21,20 @@ import seedu.address.model.meetingentry.MeetingEntry;
 class JsonSerializableLinkyTime {
     public static final String MESSAGE_DUPLICATE_MEETING_ENTRY =
             "Meeting entries list contains duplicate meeting entry(s).";
+    public static final String MESSAGE_DUPLICATE_MODULE_CODE =
+            "Module codes list contains duplicate module code(s).";
 
     private final List<JsonAdaptedMeetingEntry> meetingEntries = new ArrayList<>();
+    private final List<JsonAdaptedModuleCode> moduleCodes = new ArrayList<>();
 
     /**
      * Constructs a {@code JsonSerializableLinkyTime} with the given meeting entries.
      */
     @JsonCreator
-    public JsonSerializableLinkyTime(@JsonProperty("meetingEntries") List<JsonAdaptedMeetingEntry> meetingEntries) {
+    public JsonSerializableLinkyTime(@JsonProperty("meetingEntries") List<JsonAdaptedMeetingEntry> meetingEntries,
+                                     @JsonProperty("moduleCodes") List<JsonAdaptedModuleCode> moduleCodes) {
         this.meetingEntries.addAll(meetingEntries);
+        this.moduleCodes.addAll(moduleCodes);
     }
 
     /**
@@ -39,6 +45,8 @@ class JsonSerializableLinkyTime {
     public JsonSerializableLinkyTime(ReadOnlyLinkyTime source) {
         meetingEntries.addAll(
                 source.getMeetingEntryList().stream().map(JsonAdaptedMeetingEntry::new).collect(Collectors.toList()));
+        moduleCodes.addAll(
+                source.getModuleCodeList().stream().map(JsonAdaptedModuleCode::new).collect(Collectors.toList()));
     }
 
     /**
@@ -48,6 +56,7 @@ class JsonSerializableLinkyTime {
      */
     public LinkyTime toModelType() throws IllegalValueException {
         final LinkyTime linkyTime = new LinkyTime();
+
         for (final JsonAdaptedMeetingEntry jsonAdaptedMeetingEntry : meetingEntries) {
             final MeetingEntry meetingEntry = jsonAdaptedMeetingEntry.toModelType();
             if (linkyTime.hasMeetingEntry(meetingEntry)) {
@@ -55,6 +64,15 @@ class JsonSerializableLinkyTime {
             }
             linkyTime.addMeetingEntry(meetingEntry);
         }
+
+        for (final JsonAdaptedModuleCode jsonAdaptedModuleCode : moduleCodes) {
+            final ModuleCode moduleCode = jsonAdaptedModuleCode.toModelType();
+            if (linkyTime.hasModuleCode(moduleCode)) {
+                throw new IllegalValueException(MESSAGE_DUPLICATE_MODULE_CODE);
+            }
+            linkyTime.addModuleCode(moduleCode);
+        }
+
         return linkyTime;
     }
 

--- a/src/main/java/seedu/address/ui/MainWindow.java
+++ b/src/main/java/seedu/address/ui/MainWindow.java
@@ -32,6 +32,7 @@ public class MainWindow extends UiPart<Stage> {
 
     // Independent Ui parts residing in this Ui container
     private MeetingEntryListPanel meetingEntryListPanel;
+    private ModuleCodeListPanel moduleCodeListPanel;
     private ResultDisplay resultDisplay;
     private final HelpWindow helpWindow;
 
@@ -43,6 +44,9 @@ public class MainWindow extends UiPart<Stage> {
 
     @FXML
     private StackPane meetingEntryListPanelPlaceholder;
+
+    @FXML
+    private StackPane moduleCodeListPanelPlaceholder;
 
     @FXML
     private StackPane resultDisplayPlaceholder;
@@ -112,6 +116,9 @@ public class MainWindow extends UiPart<Stage> {
     void fillInnerParts() {
         meetingEntryListPanel = new MeetingEntryListPanel(logic.getFilteredMeetingEntryList());
         meetingEntryListPanelPlaceholder.getChildren().add(meetingEntryListPanel.getRoot());
+
+        moduleCodeListPanel = new ModuleCodeListPanel(logic.getFilteredModuleCodeList());
+        moduleCodeListPanelPlaceholder.getChildren().add(moduleCodeListPanel.getRoot());
 
         resultDisplay = new ResultDisplay();
         resultDisplayPlaceholder.getChildren().add(resultDisplay.getRoot());

--- a/src/main/java/seedu/address/ui/MeetingEntryCard.java
+++ b/src/main/java/seedu/address/ui/MeetingEntryCard.java
@@ -50,7 +50,7 @@ public class MeetingEntryCard extends UiPart<Region> {
         super(FXML);
         this.meetingEntry = meetingEntry;
         id.setText(displayedIndex + ". ");
-        moduleCode.setText(meetingEntry.getModuleCode().moduleCode);
+        moduleCode.setText(meetingEntry.getModuleCode().code);
         name.setText(meetingEntry.getName().name);
         dateTime.setText(meetingEntry.getDateTime().datetime);
         url.setText(meetingEntry.getUrl().meetingUrl.toString());

--- a/src/main/java/seedu/address/ui/MeetingEntryListPanel.java
+++ b/src/main/java/seedu/address/ui/MeetingEntryListPanel.java
@@ -34,10 +34,10 @@ public class MeetingEntryListPanel extends UiPart<Region> {
      */
     class MeetingListViewCell extends ListCell<MeetingEntry> {
         @Override
-        protected void updateItem(MeetingEntry meetingEntry, boolean empty) {
-            super.updateItem(meetingEntry, empty);
+        protected void updateItem(MeetingEntry meetingEntry, boolean isEmpty) {
+            super.updateItem(meetingEntry, isEmpty);
 
-            if (empty || meetingEntry == null) {
+            if (isEmpty || meetingEntry == null) {
                 setGraphic(null);
                 setText(null);
             } else {

--- a/src/main/java/seedu/address/ui/ModuleCodeCard.java
+++ b/src/main/java/seedu/address/ui/ModuleCodeCard.java
@@ -10,7 +10,6 @@ import seedu.address.model.modulecode.ModuleCode;
  * An UI component that displays information of a {@code ModuleCodeCard}.
  */
 public class ModuleCodeCard extends UiPart<Region> {
-
     private static final String FXML = "ModuleCodeListCard.fxml";
 
     /**

--- a/src/main/java/seedu/address/ui/ModuleCodeCard.java
+++ b/src/main/java/seedu/address/ui/ModuleCodeCard.java
@@ -1,0 +1,60 @@
+package seedu.address.ui;
+
+import javafx.fxml.FXML;
+import javafx.scene.control.Label;
+import javafx.scene.layout.HBox;
+import javafx.scene.layout.Region;
+import seedu.address.model.modulecode.ModuleCode;
+
+/**
+ * An UI component that displays information of a {@code ModuleCodeCard}.
+ */
+public class ModuleCodeCard extends UiPart<Region> {
+
+    private static final String FXML = "ModuleCodeListCard.fxml";
+
+    /**
+     * Note: Certain keywords such as "location" and "resources" are reserved keywords in JavaFX.
+     * As a consequence, UI elements' variable names cannot be set to such keywords
+     * or an exception will be thrown by JavaFX during runtime.
+     *
+     * @see <a href="https://github.com/se-edu/addressbook-level4/issues/336">The issue on AddressBook level 4</a>
+     */
+
+    public final ModuleCode moduleCode;
+
+    @FXML
+    private HBox cardPane;
+    @FXML
+    private Label id;
+    @FXML
+    private Label code;
+
+    /**
+     * Creates a {@code ModuleCodeCard} with the given {@code ModuleCode} and index to display.
+     */
+    public ModuleCodeCard(ModuleCode moduleCode, int displayedIndex) {
+        super(FXML);
+        this.moduleCode = moduleCode;
+        id.setText(displayedIndex + ". ");
+        code.setText(moduleCode.getCode());
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        // short circuit if same object
+        if (other == this) {
+            return true;
+        }
+
+        // instanceof handles nulls
+        if (!(other instanceof ModuleCodeCard)) {
+            return false;
+        }
+
+        // state check
+        final ModuleCodeCard card = (ModuleCodeCard) other;
+        return id.getText().equals(card.id.getText())
+                && moduleCode.equals(card.moduleCode);
+    }
+}

--- a/src/main/java/seedu/address/ui/ModuleCodeListPanel.java
+++ b/src/main/java/seedu/address/ui/ModuleCodeListPanel.java
@@ -34,10 +34,10 @@ public class ModuleCodeListPanel extends UiPart<Region> {
      */
     class ModuleCodeListViewCell extends ListCell<ModuleCode> {
         @Override
-        protected void updateItem(ModuleCode moduleCode, boolean empty) {
-            super.updateItem(moduleCode, empty);
+        protected void updateItem(ModuleCode moduleCode, boolean isEmpty) {
+            super.updateItem(moduleCode, isEmpty);
 
-            if (empty || moduleCode == null) {
+            if (isEmpty || moduleCode == null) {
                 setGraphic(null);
                 setText(null);
             } else {

--- a/src/main/java/seedu/address/ui/ModuleCodeListPanel.java
+++ b/src/main/java/seedu/address/ui/ModuleCodeListPanel.java
@@ -1,0 +1,49 @@
+package seedu.address.ui;
+
+import java.util.logging.Logger;
+
+import javafx.collections.ObservableList;
+import javafx.fxml.FXML;
+import javafx.scene.control.ListCell;
+import javafx.scene.control.ListView;
+import javafx.scene.layout.Region;
+import seedu.address.commons.core.LogsCenter;
+import seedu.address.model.modulecode.ModuleCode;
+
+/**
+ * Panel containing the list of module codes.
+ */
+public class ModuleCodeListPanel extends UiPart<Region> {
+    private static final String FXML = "ModuleCodeListPanel.fxml";
+    private final Logger logger = LogsCenter.getLogger(ModuleCodeListPanel.class);
+
+    @FXML
+    private ListView<ModuleCode> moduleCodeListView;
+
+    /**
+     * Creates a {@code ModuleCodeListPanel} with the given {@code ObservableList}.
+     */
+    public ModuleCodeListPanel(ObservableList<ModuleCode> moduleCodeList) {
+        super(FXML);
+        moduleCodeListView.setItems(moduleCodeList);
+        moduleCodeListView.setCellFactory(listView -> new ModuleCodeListViewCell());
+    }
+
+    /**
+     * Custom {@code ListCell} that displays the graphics of a {@code ModuleCode} using a {@code ModuleCodeCard}.
+     */
+    class ModuleCodeListViewCell extends ListCell<ModuleCode> {
+        @Override
+        protected void updateItem(ModuleCode moduleCode, boolean empty) {
+            super.updateItem(moduleCode, empty);
+
+            if (empty || moduleCode == null) {
+                setGraphic(null);
+                setText(null);
+            } else {
+                setGraphic(new ModuleCodeCard(moduleCode, getIndex() + 1).getRoot());
+            }
+        }
+    }
+
+}

--- a/src/main/resources/view/DarkTheme.css
+++ b/src/main/resources/view/DarkTheme.css
@@ -5,28 +5,32 @@
 
 .label {
     -fx-font-size: 11pt;
-    -fx-font-family: "Segoe UI Semibold";
+    -fx-font-family: "Segoe UI", "Helvetica Neue", Helvetica, Arial, sans-serif;
+    -fx-font-weight: 500;
     -fx-text-fill: #555555;
     -fx-opacity: 0.9;
 }
 
 .label-bright {
     -fx-font-size: 11pt;
-    -fx-font-family: "Segoe UI Semibold";
+    -fx-font-family: "Segoe UI", "Helvetica Neue", Helvetica, Arial, sans-serif;
+    -fx-font-weight: 500;
     -fx-text-fill: white;
     -fx-opacity: 1;
 }
 
 .label-header {
     -fx-font-size: 32pt;
-    -fx-font-family: "Segoe UI Light";
+    -fx-font-family: "Segoe UI", "Helvetica Neue", Helvetica, Arial, sans-serif;
+    -fx-font-weight: 300;
     -fx-text-fill: white;
     -fx-opacity: 1;
 }
 
 .text-field {
     -fx-font-size: 12pt;
-    -fx-font-family: "Segoe UI Semibold";
+    -fx-font-family: "Segoe UI", "Helvetica Neue", Helvetica, Arial, sans-serif;
+    -fx-font-weight: 500;
 }
 
 .tab-pane {
@@ -66,7 +70,8 @@
 
 .table-view .column-header .label {
     -fx-font-size: 20pt;
-    -fx-font-family: "Segoe UI Light";
+    -fx-font-family: "Segoe UI", "Helvetica Neue", Helvetica, Arial, sans-serif;
+    -fx-font-weight: 300;
     -fx-text-fill: white;
     -fx-alignment: center-left;
     -fx-opacity: 1;
@@ -121,13 +126,15 @@
 }
 
 .cell_big_label {
-    -fx-font-family: "Segoe UI Semibold";
+    -fx-font-family: "Segoe UI", "Helvetica Neue", Helvetica, Arial, sans-serif;
+    -fx-font-weight: 500;
     -fx-font-size: 16px;
     -fx-text-fill: #010504;
 }
 
 .cell_small_label {
-    -fx-font-family: "Segoe UI";
+    -fx-font-family: "Segoe UI", "Helvetica Neue", Helvetica, Arial, sans-serif;
+    -fx-font-weight: 400;
     -fx-font-size: 13px;
     -fx-text-fill: #010504;
 }
@@ -148,7 +155,8 @@
 
 .result-display {
     -fx-background-color: transparent;
-    -fx-font-family: "Segoe UI Light";
+    -fx-font-family: "Segoe UI", "Helvetica Neue", Helvetica, Arial, sans-serif;
+    -fx-font-weight: 300;
     -fx-font-size: 13pt;
     -fx-text-fill: white;
 }
@@ -158,7 +166,8 @@
 }
 
 .status-bar .label {
-    -fx-font-family: "Segoe UI Light";
+    -fx-font-family: "Segoe UI", "Helvetica Neue", Helvetica, Arial, sans-serif;
+    -fx-font-weight: 300;
     -fx-text-fill: white;
     -fx-padding: 4px;
     -fx-pref-height: 30px;
@@ -198,7 +207,8 @@
 
 .menu-bar .label {
     -fx-font-size: 14pt;
-    -fx-font-family: "Segoe UI Light";
+    -fx-font-family: "Segoe UI", "Helvetica Neue", Helvetica, Arial, sans-serif;
+    -fx-font-weight: 300;
     -fx-text-fill: white;
     -fx-opacity: 0.9;
 }
@@ -218,7 +228,7 @@
     -fx-border-width: 2;
     -fx-background-radius: 0;
     -fx-background-color: #1d1d1d;
-    -fx-font-family: "Segoe UI", Helvetica, Arial, sans-serif;
+    -fx-font-family: "Segoe UI", "Helvetica Neue", Helvetica, Arial, sans-serif;
     -fx-font-size: 11pt;
     -fx-text-fill: #d8d8d8;
     -fx-background-insets: 0 0 0 0, 0, 1, 2;
@@ -323,7 +333,8 @@
     -fx-border-color: #383838 #383838 #ffffff #383838;
     -fx-border-insets: 0;
     -fx-border-width: 1;
-    -fx-font-family: "Segoe UI Light";
+    -fx-font-family: "Segoe UI", "Helvetica Neue", Helvetica, Arial, sans-serif;
+    -fx-font-weight: 300;
     -fx-font-size: 13pt;
     -fx-text-fill: white;
 }

--- a/src/main/resources/view/MainWindow.fxml
+++ b/src/main/resources/view/MainWindow.fxml
@@ -11,8 +11,9 @@
 <?import javafx.scene.layout.StackPane?>
 <?import javafx.scene.layout.VBox?>
 
+<?import javafx.scene.control.Label?>
 <fx:root type="javafx.stage.Stage" xmlns="http://javafx.com/javafx/8" xmlns:fx="http://javafx.com/fxml/1"
-         title="LinkyTime App" minWidth="450" minHeight="600" onCloseRequest="#handleExit">
+         title="LinkyTime App" minWidth="520" minHeight="600" onCloseRequest="#handleExit">
   <icons>
     <Image url="@/images/address_book_32.png" />
   </icons>
@@ -39,19 +40,32 @@
           </padding>
         </StackPane>
 
-        <StackPane VBox.vgrow="NEVER" fx:id="resultDisplayPlaceholder" styleClass="pane-with-border"
-                   minHeight="100" prefHeight="100" maxHeight="100">
-          <padding>
-            <Insets top="5" right="10" bottom="5" left="10" />
-          </padding>
-        </StackPane>
+          <StackPane VBox.vgrow="SOMETIMES" fx:id="resultDisplayPlaceholder" styleClass="pane-with-border"
+                     minHeight="100" prefHeight="100" maxHeight="150">
+            <padding>
+              <Insets top="5" right="10" bottom="5" left="10" />
+            </padding>
+          </StackPane>
 
-        <VBox fx:id="meetingEntryList" styleClass="pane-with-border" minWidth="340" prefWidth="340" VBox.vgrow="ALWAYS">
-          <padding>
-            <Insets top="10" right="10" bottom="10" left="10" />
-          </padding>
-          <StackPane fx:id="meetingEntryListPanelPlaceholder" VBox.vgrow="ALWAYS"/>
-        </VBox>
+          <SplitPane orientation="HORIZONTAL" VBox.vgrow="ALWAYS" minHeight="200">
+
+            <VBox fx:id="meetingEntryList" styleClass="pane-with-border" minWidth="320" prefWidth="320">
+              <padding>
+                <Insets top="10" right="10" bottom="10" left="10" />
+              </padding>
+              <Label styleClass="label-bright">Meetings</Label>
+              <StackPane fx:id="meetingEntryListPanelPlaceholder" VBox.vgrow="ALWAYS"/>
+            </VBox>
+
+            <VBox fx:id="moduleCodeList" styleClass="pane-with-border" minWidth="160" prefWidth="160">
+              <padding>
+                <Insets top="10" right="10" bottom="10" left="10" />
+              </padding>
+              <Label styleClass="label-bright">Modules</Label>
+              <StackPane fx:id="moduleCodeListPanelPlaceholder" VBox.vgrow="ALWAYS"/>
+            </VBox>
+
+          </SplitPane>
 
         <StackPane fx:id="statusbarPlaceholder" VBox.vgrow="NEVER" />
       </VBox>

--- a/src/main/resources/view/MainWindow.fxml
+++ b/src/main/resources/view/MainWindow.fxml
@@ -10,8 +10,8 @@
 <?import javafx.scene.image.Image?>
 <?import javafx.scene.layout.StackPane?>
 <?import javafx.scene.layout.VBox?>
-
 <?import javafx.scene.control.Label?>
+
 <fx:root type="javafx.stage.Stage" xmlns="http://javafx.com/javafx/8" xmlns:fx="http://javafx.com/fxml/1"
          title="LinkyTime App" minWidth="520" minHeight="600" onCloseRequest="#handleExit">
   <icons>

--- a/src/main/resources/view/MainWindow.fxml
+++ b/src/main/resources/view/MainWindow.fxml
@@ -40,32 +40,30 @@
           </padding>
         </StackPane>
 
-          <StackPane VBox.vgrow="SOMETIMES" fx:id="resultDisplayPlaceholder" styleClass="pane-with-border"
-                     minHeight="100" prefHeight="100" maxHeight="150">
+        <StackPane VBox.vgrow="SOMETIMES" fx:id="resultDisplayPlaceholder" styleClass="pane-with-border"
+                   minHeight="100" prefHeight="100" maxHeight="150">
+          <padding>
+            <Insets top="5" right="10" bottom="5" left="10" />
+          </padding>
+        </StackPane>
+
+        <SplitPane orientation="HORIZONTAL" VBox.vgrow="ALWAYS" minHeight="200">
+          <VBox fx:id="meetingEntryList" styleClass="pane-with-border" minWidth="320" prefWidth="320">
             <padding>
-              <Insets top="5" right="10" bottom="5" left="10" />
+              <Insets top="10" right="10" bottom="10" left="10" />
             </padding>
-          </StackPane>
+            <Label styleClass="label-bright">Meetings</Label>
+            <StackPane fx:id="meetingEntryListPanelPlaceholder" VBox.vgrow="ALWAYS"/>
+          </VBox>
 
-          <SplitPane orientation="HORIZONTAL" VBox.vgrow="ALWAYS" minHeight="200">
-
-            <VBox fx:id="meetingEntryList" styleClass="pane-with-border" minWidth="320" prefWidth="320">
-              <padding>
-                <Insets top="10" right="10" bottom="10" left="10" />
-              </padding>
-              <Label styleClass="label-bright">Meetings</Label>
-              <StackPane fx:id="meetingEntryListPanelPlaceholder" VBox.vgrow="ALWAYS"/>
-            </VBox>
-
-            <VBox fx:id="moduleCodeList" styleClass="pane-with-border" minWidth="160" prefWidth="160">
-              <padding>
-                <Insets top="10" right="10" bottom="10" left="10" />
-              </padding>
-              <Label styleClass="label-bright">Modules</Label>
-              <StackPane fx:id="moduleCodeListPanelPlaceholder" VBox.vgrow="ALWAYS"/>
-            </VBox>
-
-          </SplitPane>
+          <VBox fx:id="moduleCodeList" styleClass="pane-with-border" minWidth="160" prefWidth="160">
+            <padding>
+              <Insets top="10" right="10" bottom="10" left="10" />
+            </padding>
+            <Label styleClass="label-bright">Modules</Label>
+            <StackPane fx:id="moduleCodeListPanelPlaceholder" VBox.vgrow="ALWAYS"/>
+          </VBox>
+        </SplitPane>
 
         <StackPane fx:id="statusbarPlaceholder" VBox.vgrow="NEVER" />
       </VBox>

--- a/src/main/resources/view/ModuleCodeListCard.fxml
+++ b/src/main/resources/view/ModuleCodeListCard.fxml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<?import javafx.geometry.Insets?>
+<?import javafx.scene.control.Label?>
+<?import javafx.scene.layout.ColumnConstraints?>
+<?import javafx.scene.layout.GridPane?>
+<?import javafx.scene.layout.HBox?>
+<?import javafx.scene.layout.Region?>
+<?import javafx.scene.layout.VBox?>
+
+<HBox id="cardPane" fx:id="cardPane" xmlns="http://javafx.com/javafx/8" xmlns:fx="http://javafx.com/fxml/1">
+  <GridPane HBox.hgrow="ALWAYS">
+    <columnConstraints>
+      <ColumnConstraints hgrow="SOMETIMES" minWidth="30" prefWidth="150" />
+    </columnConstraints>
+    <VBox spacing="2" alignment="CENTER_LEFT" minHeight="50" GridPane.columnIndex="0">
+      <padding>
+        <Insets top="5" right="5" bottom="5" left="15" />
+      </padding>
+      <HBox spacing="5" alignment="CENTER_LEFT">
+        <Label fx:id="id" styleClass="cell_big_label">
+          <minWidth>
+            <!-- Ensures that the label text is never truncated -->
+            <Region fx:constant="USE_PREF_SIZE" />
+          </minWidth>
+        </Label>
+        <Label fx:id="code" text="\$code" styleClass="cell_big_label" />
+      </HBox>
+    </VBox>
+  </GridPane>
+</HBox>

--- a/src/main/resources/view/ModuleCodeListPanel.fxml
+++ b/src/main/resources/view/ModuleCodeListPanel.fxml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<?import javafx.scene.control.ListView?>
+<?import javafx.scene.layout.VBox?>
+
+<VBox xmlns="http://javafx.com/javafx/8" xmlns:fx="http://javafx.com/fxml/1">
+  <ListView fx:id="moduleCodeListView" VBox.vgrow="ALWAYS" />
+</VBox>

--- a/src/test/java/seedu/address/logic/commands/AddCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/AddCommandTest.java
@@ -23,6 +23,7 @@ import seedu.address.model.ReadOnlyAddressBook;
 import seedu.address.model.ReadOnlyLinkyTime;
 import seedu.address.model.ReadOnlyUserPrefs;
 import seedu.address.model.meetingentry.MeetingEntry;
+import seedu.address.model.modulecode.ModuleCode;
 import seedu.address.model.person.Person;
 import seedu.address.testutil.MeetingEntryBuilder;
 
@@ -150,6 +151,21 @@ public class AddCommandTest {
 
         @Override
         public void updateFilteredMeetingEntryList(Predicate<MeetingEntry> predicate) {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
+        public boolean hasModuleCode(ModuleCode moduleCode) {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
+        public ObservableList<ModuleCode> getFilteredModuleCodeList() {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
+        public void updateFilteredModuleCodeList(Predicate<ModuleCode> predicate) {
             throw new AssertionError("This method should not be called.");
         }
 


### PR DESCRIPTION
## Related issues
Closes #52 
Closes #57 

## Description
<img width="600" alt="image" src="https://user-images.githubusercontent.com/43518715/158540323-55b89834-b0a0-40c2-9193-5aa2cc929132.png">

1. Main GUI has been updated to display the list of module codes.
2. `mlist` command to display the list of module codes has been implemented.

## How to test
1. Replace `app.json` with the [following file](https://pastebin.com/raw/WmVhrpJe). (Keep a copy of your existing data file somewhere first)
2. Start the application.

## Other information
- The `-fx-font-family` attribute has been updated to include additional fallbacks. On macOS, the Segoe UI font family is not installed by default. I will need someone with a Windows machine to test if the UI is working fine on their side, and leave a comment if there are issues.
- Test cases have not been written yet. I think we should consider refactoring the test cases and group them into packages. List of proposed changes (to be done in another PR):
  - Refactor test cases for `MeetingEntry` and `ModuleCode`-related classes into their own packages
  - Rename existing commands for `MeetingEntry`, e.g. `AddCommand` into `AddMeetingEntryCommand` to prevent ambiguity
