### PR TITLE
Enable assertions

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -21,8 +21,13 @@ checkstyle {
 }
 
 test {
+    enableAssertions = true
     useJUnitPlatform()
     finalizedBy jacocoTestReport
+}
+
+run {
+    enableAssertions = true
 }
 
 task coverage(type: JacocoReport) {


### PR DESCRIPTION
## Related issues
Closes #97 

## Description

- Enables assertions in the `run` and `test` gradle configurations
- You may need to enable assertions in IntelliJ as outlined [here](https://se-education.org/guides/tutorials/intellijUsefulSettings.html) 