### PR TITLE
Fix URL validation regex and text wrapping

### DIFF
--- a/src/main/java/seedu/address/model/meeting/MeetingUrl.java
+++ b/src/main/java/seedu/address/model/meeting/MeetingUrl.java
@@ -6,6 +6,8 @@ import static seedu.address.commons.util.AppUtil.checkArgument;
 import java.net.MalformedURLException;
 import java.net.URL;
 
+import seedu.address.model.meeting.exceptions.InvalidUrlException;
+
 /**
  * Represents a Meeting's URL in the meeting list.
  * Guarantees: immutable; is valid as declared in {@link #isValidUrl(String)}
@@ -14,6 +16,16 @@ public class MeetingUrl {
 
     public static final String MESSAGE_CONSTRAINTS =
             "URLs should be a valid link, and it should not be blank";
+
+    /* Regex to check if a string starts with `http[s]://`. */
+    public static final String HTTP_REGEX = "^(https?)://.*$";
+
+    /* Adapted from Diego Perini https://gist.github.com/dperini/729294 */
+    public static final String VALIDATION_REGEX = "^(?:(?:(?:https?):)?\\/\\/)(?:\\S+(?::\\S*)?@)?(?:(?!(?:10|127)"
+            + "(?:\\.\\d{1,3}){3})(?!(?:169\\.254|192\\.168)(?:\\.\\d{1,3}){2})(?!172\\.(?:1[6-9]|2\\d|3[0-1])"
+            + "(?:\\.\\d{1,3}){2})(?:[1-9]\\d?|1\\d\\d|2[01]\\d|22[0-3])(?:\\.(?:1?\\d{1,2}|2[0-4]\\d|25[0-5])){2}"
+            + "(?:\\.(?:[1-9]\\d?|1\\d\\d|2[0-4]\\d|25[0-4]))|(?:(?:[a-z0-9\\u00a1-\\uffff][a-z0-9\\u00a1-\\uffff_-]"
+            + "{0,62})?[a-z0-9\\u00a1-\\uffff]\\.)+(?:[a-z\\u00a1-\\uffff]{2,}\\.?))(?::\\d{2,5})?(?:[/?#]\\S*)?$";
 
     public final URL meetingUrl;
 
@@ -35,12 +47,8 @@ public class MeetingUrl {
      * @return True if the URL {@code String} is valid.
      */
     public static boolean isValidUrl(String test) {
-        try {
-            new URL(test).toURI();
-            return true;
-        } catch (Exception e) {
-            return false;
-        }
+        test = checkAndAppendHttps(test);
+        return test.matches(VALIDATION_REGEX);
     }
 
     /**
@@ -51,14 +59,25 @@ public class MeetingUrl {
      */
     public static URL parseUrl(String url) {
         try {
+            url = checkAndAppendHttps(url);
             return new URL(url);
         } catch (MalformedURLException e) {
-            e.printStackTrace();
-            // TODO: update this once we've figured out exception handling
-            return null;
+            throw new InvalidUrlException(String.format("%s is not a valid URL", url));
         }
     }
 
+    /**
+     * Appends `https://` to {@code url} if it does not start with it.
+     *
+     * @param url The string to check.
+     * @return The url string with https:// prefixed to it.
+     */
+    public static String checkAndAppendHttps(String url) {
+        if (!url.matches(HTTP_REGEX)) {
+            url = "https://" + url;
+        }
+        return url;
+    }
 
     @Override
     public String toString() {

--- a/src/main/java/seedu/address/model/meeting/MeetingUrl.java
+++ b/src/main/java/seedu/address/model/meeting/MeetingUrl.java
@@ -47,7 +47,6 @@ public class MeetingUrl {
      * @return True if the URL {@code String} is valid.
      */
     public static boolean isValidUrl(String test) {
-        test = checkAndPrependHttps(test);
         return test.matches(VALIDATION_REGEX);
     }
 
@@ -59,24 +58,10 @@ public class MeetingUrl {
      */
     public static URL parseUrl(String url) {
         try {
-            url = checkAndPrependHttps(url);
             return new URL(url);
         } catch (MalformedURLException e) {
             throw new InvalidUrlException(String.format("%s is not a valid URL", url));
         }
-    }
-
-    /**
-     * Prepends `https://` to {@code url} if it does not start with it.
-     *
-     * @param url The string to check.
-     * @return The url string with https:// prepended to it.
-     */
-    public static String checkAndPrependHttps(String url) {
-        if (!url.matches(HTTP_REGEX)) {
-            url = "https://" + url;
-        }
-        return url;
     }
 
     @Override

--- a/src/main/java/seedu/address/model/meeting/MeetingUrl.java
+++ b/src/main/java/seedu/address/model/meeting/MeetingUrl.java
@@ -67,10 +67,10 @@ public class MeetingUrl {
     }
 
     /**
-     * Appends `https://` to {@code url} if it does not start with it.
+     * Prepends `https://` to {@code url} if it does not start with it.
      *
      * @param url The string to check.
-     * @return The url string with https:// prefixed to it.
+     * @return The url string with https:// prepended to it.
      */
     public static String checkAndPrependHttps(String url) {
         if (!url.matches(HTTP_REGEX)) {

--- a/src/main/java/seedu/address/model/meeting/MeetingUrl.java
+++ b/src/main/java/seedu/address/model/meeting/MeetingUrl.java
@@ -17,6 +17,9 @@ public class MeetingUrl {
     public static final String MESSAGE_CONSTRAINTS =
             "URLs should be a valid link, and it should not be blank";
 
+    /* Regex to check if a string starts with `http[s]://`. */
+    public static final String HTTP_REGEX = "^(https?)://.*$";
+
     /* Adapted from Diego Perini https://gist.github.com/dperini/729294 */
     public static final String VALIDATION_REGEX = "^(?:(?:(?:https?):)?\\/\\/)(?:\\S+(?::\\S*)?@)?(?:(?!(?:10|127)"
             + "(?:\\.\\d{1,3}){3})(?!(?:169\\.254|192\\.168)(?:\\.\\d{1,3}){2})(?!172\\.(?:1[6-9]|2\\d|3[0-1])"
@@ -44,6 +47,7 @@ public class MeetingUrl {
      * @return True if the URL {@code String} is valid.
      */
     public static boolean isValidUrl(String test) {
+        test = checkAndPrependHttps(test);
         return test.matches(VALIDATION_REGEX);
     }
 
@@ -55,10 +59,24 @@ public class MeetingUrl {
      */
     public static URL parseUrl(String url) {
         try {
+            url = checkAndPrependHttps(url);
             return new URL(url);
         } catch (MalformedURLException e) {
             throw new InvalidUrlException(String.format("%s is not a valid URL", url));
         }
+    }
+
+    /**
+     * Prepends {@code https://} to {@code url} if it does not start with it.
+     *
+     * @param url The string to check.
+     * @return The url string with {@code https://} prepended to it.
+     */
+    public static String checkAndPrependHttps(String url) {
+        if (!url.matches(HTTP_REGEX)) {
+            url = "https://" + url;
+        }
+        return url;
     }
 
     @Override

--- a/src/main/java/seedu/address/model/meeting/MeetingUrl.java
+++ b/src/main/java/seedu/address/model/meeting/MeetingUrl.java
@@ -17,9 +17,6 @@ public class MeetingUrl {
     public static final String MESSAGE_CONSTRAINTS =
             "URLs should be a valid link, and it should not be blank";
 
-    /* Regex to check if a string starts with `http[s]://`. */
-    public static final String HTTP_REGEX = "^(https?)://.*$";
-
     /* Adapted from Diego Perini https://gist.github.com/dperini/729294 */
     public static final String VALIDATION_REGEX = "^(?:(?:(?:https?):)?\\/\\/)(?:\\S+(?::\\S*)?@)?(?:(?!(?:10|127)"
             + "(?:\\.\\d{1,3}){3})(?!(?:169\\.254|192\\.168)(?:\\.\\d{1,3}){2})(?!172\\.(?:1[6-9]|2\\d|3[0-1])"

--- a/src/main/java/seedu/address/model/meeting/MeetingUrl.java
+++ b/src/main/java/seedu/address/model/meeting/MeetingUrl.java
@@ -47,7 +47,7 @@ public class MeetingUrl {
      * @return True if the URL {@code String} is valid.
      */
     public static boolean isValidUrl(String test) {
-        test = checkAndAppendHttps(test);
+        test = checkAndPrependHttps(test);
         return test.matches(VALIDATION_REGEX);
     }
 
@@ -59,7 +59,7 @@ public class MeetingUrl {
      */
     public static URL parseUrl(String url) {
         try {
-            url = checkAndAppendHttps(url);
+            url = checkAndPrependHttps(url);
             return new URL(url);
         } catch (MalformedURLException e) {
             throw new InvalidUrlException(String.format("%s is not a valid URL", url));
@@ -72,7 +72,7 @@ public class MeetingUrl {
      * @param url The string to check.
      * @return The url string with https:// prefixed to it.
      */
-    public static String checkAndAppendHttps(String url) {
+    public static String checkAndPrependHttps(String url) {
         if (!url.matches(HTTP_REGEX)) {
             url = "https://" + url;
         }

--- a/src/main/java/seedu/address/model/meeting/exceptions/InvalidUrlException.java
+++ b/src/main/java/seedu/address/model/meeting/exceptions/InvalidUrlException.java
@@ -1,0 +1,7 @@
+package seedu.address.model.meeting.exceptions;
+
+public class InvalidUrlException extends RuntimeException {
+    public InvalidUrlException(String message) {
+        super(message);
+    }
+}

--- a/src/main/resources/view/MeetingCard.fxml
+++ b/src/main/resources/view/MeetingCard.fxml
@@ -34,7 +34,7 @@
         <Label styleClass="label-bright"> - </Label>
         <Label fx:id="endDateTime" styleClass="cell_small_label" text="\$endDateTime" />
       </HBox>
-      <Label fx:id="url" styleClass="cell_small_label" text="\$url" />
+      <Label fx:id="url" styleClass="cell_small_label" text="\$url" wrapText="true" />
       <FlowPane fx:id="tags" />
     </VBox>
   </GridPane>


### PR DESCRIPTION
## Related issues
Closes #139 
Closes #170 
Closes #156

## Description
* Fixed URL validation with proper regex (original regex attribution included in code)
* Enable URL text wrapping in the UI

## How to test
1. Launch the app.
2. Run the following command: `add n/Testing URL u/nus-sg.zoom.us/j/88543620358?pwd=V05IVXM2cVNCVUlpYld6WUNCZytkdz09 d/10-05-2022 1200 dur/1 m/2 r/N`. The meeting is created successfully.
3. Run the following incorrect commands: 
    * `add n/Wrong URL u/google d/10-05-2022 1200 dur/1 m/2 r/N`
    * `add n/Wrong URL u/https://google d/10-05-2022 1200 dur/1 m/2 r/N`
    * `add n/Wrong URL u/https:// d/10-05-2022 1200 dur/1 m/2 r/N`
    * `add n/Wrong URL u/https://.com d/10-05-2022 1200 dur/1 m/2 r/N`
    * `add n/Wrong URL u/.com d/10-05-2022 1200 dur/1 m/2 r/N`
4. The commands above should fail with the correct error message printed.

## Other information
<!--
This section is optional, you may include things like:
- What is left to be done after this
- Any questions or assistance you may require
-->
