### PR TITLE
Add manual testing instructions for add and edit meeting

### DIFF
--- a/docs/DeveloperGuide.md
+++ b/docs/DeveloperGuide.md
@@ -657,6 +657,51 @@ testers are expected to do more *exploratory* testing.
 
 1. _{ more test cases …​ }_
 
+### Meeting
+
+#### Adding Meetings
+1. Test case: `add n/Lecture u/https://www.zoom.com d/25-03-2022 1400 dur/1.5 m/1 r/Y t/recorded t/lecturequiz`
+   Prerequisites:
+      1. There is no other meetings with the exact same fields.
+      2. There is one module in the module list.
+   Expected: Meeting is added.
+2. Incorrect commands:
+   1. Duplicate meeting 
+      Prerequisite:
+         1. The testcase command was just entered.
+      Command: `add n/Lecture u/https://www.zoom.com d/25-03-2022 1400 dur/1.5 m/1 r/Y t/recorded t/lecturequiz`.
+   2. Incorrect name
+      Command: `add n/Lectur$ u/https://www.zoom.com d/25-03-2022 1400 dur/1.5 m/1 r/Y t/recorded t/lecturequiz`.
+   3. Incorrect url
+      Command: `add n/Lecture u/zoom d/25-03-2022 1400 dur/1.5 m/1 r/Y t/recorded t/lecturequiz`.
+   4. Incorrect date
+      Command: `add n/Lecture u/https://www.zoom.com d/40-03-2022 1400 dur/1.5 m/1 r/Y t/recorded t/lecturequiz`.
+   5. Incorrect time
+      Command: `add n/Lecture u/https://www.zoom.com d/25-03-2022 2500 dur/1.5 m/1 r/Y t/recorded t/lecturequiz`.
+   6. Incorrect duration
+      Command: `add n/Lecture u/https://www.zoom.com d/25-03-2022 1400 dur/25 m/1 r/Y t/recorded t/lecturequiz`.
+   7. Incorrect module index
+      Command: `add n/Lecture u/https://www.zoom.com d/25-03-2022 1400 dur/1.5 m/10 r/Y t/recorded t/lecturequiz`.
+   8. Incorrect recurrence
+      Command: `add n/Lecture u/https://www.zoom.com d/25-03-2022 1400 dur/1.5 m/1 r/A t/recorded t/lecturequiz`.
+   9. Incorrect tag
+      Command: `add n/Lecture u/https://www.zoom.com d/25-03-2022 1400 dur/1.5 m/1 r/Y t/recorded t/!ecturequiz`.
+   For each of the incorrect commands, there will be an error message included on how to rectify the issue.
+
+#### Edit Meetings
+1. Test case: `edit 1 n/Lecture`
+   Prerequisites:
+      1. There is at least one meeting in the meeting list.
+   Expected: The meeting at the first index is edited.
+2. Incorrect commands:
+   For each field of the meeting, you can refer to the Add Meetings of the Instructions for manual testing as they are exactly the same.
+   1. Duplicate meeting 
+      Prerequisite:
+         1. There is a meeting in the meeting list at index 4 which was added using the command `add n/Lecture u/https://www.zoom.com d/25-03-2022 1400 dur/1.5 m/1 r/Y t/recorded t/lecturequiz`.
+         2. There is a meeting in the meeting list at index 1 which was added using the command `add n/Tutorial u/https://www.zoom.com d/25-03-2022 1400 dur/1.5 m/1 r/Y t/recorded t/lecturequiz`
+      Command: `edit 1 n/Lecture`
+      Expected: There will be an error message included on how to rectify the issue.
+         
 ### Deleting a person
 
 1. Deleting a person while all persons are being shown


### PR DESCRIPTION
## Related issues
<!-- Please link to the Github issue(s) this PR resolves (type `#` to autocomplete issue) -->
For #58

## Description
<!-- Describe your changes -->
<!-- If it affects UI, screenshots are highly recommended -->
Added the manual testing instructions for adding and editing of meeting.
