### PR TITLE
Append custom index type in front of `parseIndex` error message

### DIFF
--- a/src/main/java/seedu/address/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/address/logic/parser/ParserUtil.java
@@ -4,7 +4,6 @@ import static java.util.Objects.requireNonNull;
 
 import java.util.Collection;
 import java.util.HashSet;
-import java.util.Optional;
 import java.util.Set;
 
 import seedu.address.commons.core.index.Index;
@@ -24,7 +23,6 @@ import seedu.address.model.tag.Tag;
 public class ParserUtil {
 
     public static final String MESSAGE_INVALID_INDEX = "Index is not a non-zero unsigned integer.";
-    public static final String MESSAGE_INVALID_INDEX_FOR = "%s index is not a non-zero unsigned integer.";
 
     /**
      * Parses {@code oneBasedIndex} into an {@code Index} and returns it. Leading and trailing whitespaces will be
@@ -32,7 +30,7 @@ public class ParserUtil {
      * @throws ParseException if the specified index is invalid (not non-zero unsigned integer).
      */
     public static Index parseIndex(String oneBasedIndex) throws ParseException {
-        return parseIndex(oneBasedIndex, "");
+        return parseIndexWithErrMsg(oneBasedIndex, MESSAGE_INVALID_INDEX);
     }
 
     /**
@@ -41,23 +39,16 @@ public class ParserUtil {
      * @throws ParseException if the specified index is invalid (not non-zero unsigned integer).
      */
     public static Index parseIndex(String oneBasedIndex, String indexType) throws ParseException {
-        final Optional<Index> index = tryParseIndex(oneBasedIndex);
-        if (index.isPresent()) {
-            return index.get();
-        }
-        final String processedIndexType = processIndexType(indexType);
-        if (processedIndexType.isEmpty()) {
-            throw new ParseException(MESSAGE_INVALID_INDEX);
-        }
-        throw new ParseException(String.format(MESSAGE_INVALID_INDEX_FOR, processedIndexType));
+        final String errMsg = String.format("%s %s", processIndexType(indexType), MESSAGE_INVALID_INDEX).trim();
+        return parseIndexWithErrMsg(oneBasedIndex, errMsg);
     }
 
-    private static Optional<Index> tryParseIndex(String oneBasedIndex) {
-        String trimmedIndex = oneBasedIndex.trim();
+    private static Index parseIndexWithErrMsg(String oneBasedIndex, String errMsg) throws ParseException {
+        final String trimmedIndex = oneBasedIndex.trim();
         if (!StringUtil.isNonZeroUnsignedInteger(trimmedIndex)) {
-            return Optional.empty();
+            throw new ParseException(errMsg);
         }
-        return Optional.ofNullable(Index.fromOneBased(Integer.parseInt(trimmedIndex)));
+        return Index.fromOneBased(Integer.parseInt(trimmedIndex));
     }
 
     private static String processIndexType(String indexType) {

--- a/src/main/java/seedu/address/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/address/logic/parser/ParserUtil.java
@@ -4,6 +4,7 @@ import static java.util.Objects.requireNonNull;
 
 import java.util.Collection;
 import java.util.HashSet;
+import java.util.Optional;
 import java.util.Set;
 
 import seedu.address.commons.core.index.Index;
@@ -23,6 +24,7 @@ import seedu.address.model.tag.Tag;
 public class ParserUtil {
 
     public static final String MESSAGE_INVALID_INDEX = "Index is not a non-zero unsigned integer.";
+    public static final String MESSAGE_INVALID_INDEX_FOR = "%s index is not a non-zero unsigned integer.";
 
     /**
      * Parses {@code oneBasedIndex} into an {@code Index} and returns it. Leading and trailing whitespaces will be
@@ -30,11 +32,40 @@ public class ParserUtil {
      * @throws ParseException if the specified index is invalid (not non-zero unsigned integer).
      */
     public static Index parseIndex(String oneBasedIndex) throws ParseException {
-        String trimmedIndex = oneBasedIndex.trim();
-        if (!StringUtil.isNonZeroUnsignedInteger(trimmedIndex)) {
+        return parseIndex(oneBasedIndex, "");
+    }
+
+    /**
+     * Parses {@code oneBasedIndex} into an {@code Index} and returns it. Leading and trailing whitespaces will be
+     * trimmed. If the operation fails, a {@code ParseException} indicating the {@code indexType} will be thrown.
+     * @throws ParseException if the specified index is invalid (not non-zero unsigned integer).
+     */
+    public static Index parseIndex(String oneBasedIndex, String indexType) throws ParseException {
+        final Optional<Index> index = tryParseIndex(oneBasedIndex);
+        if (index.isPresent()) {
+            return index.get();
+        }
+        final String processedIndexType = processIndexType(indexType);
+        if (processedIndexType.isEmpty()) {
             throw new ParseException(MESSAGE_INVALID_INDEX);
         }
-        return Index.fromOneBased(Integer.parseInt(trimmedIndex));
+        throw new ParseException(String.format(MESSAGE_INVALID_INDEX_FOR, processedIndexType));
+    }
+
+    private static Optional<Index> tryParseIndex(String oneBasedIndex) {
+        String trimmedIndex = oneBasedIndex.trim();
+        if (!StringUtil.isNonZeroUnsignedInteger(trimmedIndex)) {
+            return Optional.empty();
+        }
+        return Optional.ofNullable(Index.fromOneBased(Integer.parseInt(trimmedIndex)));
+    }
+
+    private static String processIndexType(String indexType) {
+        final String trimmed = indexType.trim();
+        if (trimmed.isEmpty()) {
+            return trimmed;
+        }
+        return Character.toUpperCase(trimmed.charAt(0)) + trimmed.substring(1).toLowerCase();
     }
 
     /**

--- a/src/main/java/seedu/address/logic/parser/meeting/AddMeetingCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/meeting/AddMeetingCommandParser.java
@@ -53,7 +53,7 @@ public class AddMeetingCommandParser implements Parser<AddMeetingCommand> {
         final MeetingUrl url = ParserUtil.parseMeetingUrl(argMultimap.getValue(PREFIX_URL).get());
         final MeetingDateTime dateTime = ParserUtil.parseMeetingDateTime(argMultimap.getValue(PREFIX_DATETIME).get());
         final MeetingDuration duration = ParserUtil.parseMeetingDuration(argMultimap.getValue(PREFIX_DURATION).get());
-        final Index moduleIndex = ParserUtil.parseIndex(argMultimap.getValue(PREFIX_MODULE).get());
+        final Index moduleIndex = ParserUtil.parseIndex(argMultimap.getValue(PREFIX_MODULE).get(), "Module");
         final IsRecurring recurringStatus = ParserUtil.parseRecurringStatus(argMultimap
                 .getValue(PREFIX_RECURRING).get());
         final Set<Tag> tagList = ParserUtil.parseTags(argMultimap.getAllValues(PREFIX_TAG));

--- a/src/main/java/seedu/address/logic/parser/meeting/EditMeetingCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/meeting/EditMeetingCommandParser.java
@@ -74,7 +74,7 @@ public class EditMeetingCommandParser implements Parser<EditMeetingCommand> {
             editMeetingDescriptor.setDuration(duration);
         }
         if (argMultimap.getValue(PREFIX_MODULE).isPresent()) {
-            final Index moduleIndex = ParserUtil.parseIndex(argMultimap.getValue(PREFIX_MODULE).get());
+            final Index moduleIndex = ParserUtil.parseIndex(argMultimap.getValue(PREFIX_MODULE).get(), "Module");
             editMeetingDescriptor.setModuleIndex(moduleIndex);
         }
         if (argMultimap.getValue(PREFIX_RECURRING).isPresent()) {

--- a/src/test/java/seedu/address/logic/parser/ParserUtilTest.java
+++ b/src/test/java/seedu/address/logic/parser/ParserUtilTest.java
@@ -3,6 +3,7 @@ package seedu.address.logic.parser;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static seedu.address.logic.parser.ParserUtil.MESSAGE_INVALID_INDEX;
+import static seedu.address.logic.parser.ParserUtil.MESSAGE_INVALID_INDEX_FOR;
 import static seedu.address.testutil.Assert.assertThrows;
 import static seedu.address.testutil.typical.TypicalIndexes.INDEX_FIRST_MEETING;
 
@@ -24,20 +25,51 @@ import seedu.address.model.tag.Tag;
  */
 public class ParserUtilTest {
 
+    private static final String VALID_INDEX_TYPE_1 = "Module";
+    private static final String VALID_INDEX_TYPE_2 = "M";
+    private static final String EMPTY_INDEX_TYPE = "";
     private static final String INVALID_TAG = "#friend";
     private static final String VALID_TAG_1 = "friend";
     private static final String VALID_TAG_2 = "neighbour";
     private static final String WHITESPACE = " \t\r\n";
 
+    private String createParseIndexErrMsg(String indexType) {
+        if (indexType.isEmpty()) {
+            return MESSAGE_INVALID_INDEX;
+        }
+        return String.format(MESSAGE_INVALID_INDEX_FOR, indexType);
+    }
+
     @Test
     public void parseIndex_invalidInput_throwsParseException() {
-        assertThrows(ParseException.class, () -> ParserUtil.parseIndex("10 a"));
+        final String indexInput = "10 a";
+
+        // Test variant of `parseIndex` that does not accept an `indexType`.
+        assertThrows(ParseException.class, MESSAGE_INVALID_INDEX, () -> ParserUtil.parseIndex(indexInput));
+
+        // Test variant of `parseIndex` that accepts an `indexType`.
+        assertThrows(ParseException.class, MESSAGE_INVALID_INDEX, () ->
+                ParserUtil.parseIndex(indexInput, EMPTY_INDEX_TYPE));
+        assertThrows(ParseException.class, createParseIndexErrMsg(VALID_INDEX_TYPE_1), () ->
+                ParserUtil.parseIndex(indexInput, VALID_INDEX_TYPE_1));
+        assertThrows(ParseException.class, createParseIndexErrMsg(VALID_INDEX_TYPE_2), () ->
+                ParserUtil.parseIndex(indexInput, VALID_INDEX_TYPE_2));
     }
 
     @Test
     public void parseIndex_outOfRangeInput_throwsParseException() {
-        assertThrows(ParseException.class,
-                MESSAGE_INVALID_INDEX, () -> ParserUtil.parseIndex(Long.toString(Integer.MAX_VALUE + 1)));
+        final String indexInput = Long.toString(Integer.MAX_VALUE + 1);
+
+        // Test variant of `parseIndex` that does not accept an `indexType`.
+        assertThrows(ParseException.class, MESSAGE_INVALID_INDEX, () -> ParserUtil.parseIndex(indexInput));
+
+        // Test variant of `parseIndex` that accepts an `indexType`.
+        assertThrows(ParseException.class, MESSAGE_INVALID_INDEX, () ->
+                ParserUtil.parseIndex(indexInput, EMPTY_INDEX_TYPE));
+        assertThrows(ParseException.class, createParseIndexErrMsg(VALID_INDEX_TYPE_1), () ->
+                ParserUtil.parseIndex(indexInput, VALID_INDEX_TYPE_1));
+        assertThrows(ParseException.class, createParseIndexErrMsg(VALID_INDEX_TYPE_2), () ->
+                ParserUtil.parseIndex(indexInput, VALID_INDEX_TYPE_2));
     }
 
     @Test

--- a/src/test/java/seedu/address/logic/parser/ParserUtilTest.java
+++ b/src/test/java/seedu/address/logic/parser/ParserUtilTest.java
@@ -3,7 +3,6 @@ package seedu.address.logic.parser;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static seedu.address.logic.parser.ParserUtil.MESSAGE_INVALID_INDEX;
-import static seedu.address.logic.parser.ParserUtil.MESSAGE_INVALID_INDEX_FOR;
 import static seedu.address.testutil.Assert.assertThrows;
 import static seedu.address.testutil.typical.TypicalIndexes.INDEX_FIRST_MEETING;
 
@@ -34,10 +33,7 @@ public class ParserUtilTest {
     private static final String WHITESPACE = " \t\r\n";
 
     private String createParseIndexErrMsg(String indexType) {
-        if (indexType.isEmpty()) {
-            return MESSAGE_INVALID_INDEX;
-        }
-        return String.format(MESSAGE_INVALID_INDEX_FOR, indexType);
+        return String.format("%s %s", indexType.trim(), MESSAGE_INVALID_INDEX).trim();
     }
 
     @Test

--- a/src/test/java/seedu/address/logic/parser/ParserUtilTest.java
+++ b/src/test/java/seedu/address/logic/parser/ParserUtilTest.java
@@ -25,6 +25,8 @@ import seedu.address.model.tag.Tag;
 public class ParserUtilTest {
 
     private static final String VALID_INDEX_TYPE_1 = "Module";
+    // As the first character of the index type is extracted for capitalization, we need to test this one character
+    // edge case to ensure that no unexpected error occurs (e.g. out of bounds access on the index type string).
     private static final String VALID_INDEX_TYPE_2 = "M";
     private static final String EMPTY_INDEX_TYPE = "";
     private static final String INVALID_TAG = "#friend";

--- a/src/test/java/seedu/address/logic/parser/meeting/AddMeetingCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/meeting/AddMeetingCommandParserTest.java
@@ -184,7 +184,7 @@ public class AddMeetingCommandParserTest {
         // invalid module
         assertParseFailure(parser, NAME_DESC_LECTURE + URL_DESC_LECTURE
                 + DATETIME_DESC_LECTURE + DURATION_DESC_LECTURE + INVALID_MODULE_DESC
-                + RECURRING_DESC_LECTURE + TAG_DESC_LECTURE, ParserUtil.MESSAGE_INVALID_INDEX);
+                + RECURRING_DESC_LECTURE + TAG_DESC_LECTURE, "Module " + ParserUtil.MESSAGE_INVALID_INDEX);
 
         // invalid isRecurring
         assertParseFailure(parser, NAME_DESC_LECTURE + URL_DESC_LECTURE

--- a/src/test/java/seedu/address/logic/parser/meeting/EditMeetingCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/meeting/EditMeetingCommandParserTest.java
@@ -101,7 +101,8 @@ public class EditMeetingCommandParserTest {
         assertParseFailure(parser, "1" + INVALID_DURATION_DESC, MeetingDuration.MESSAGE_CONSTRAINTS);
 
         // invalid module
-        assertParseFailure(parser, "1" + INVALID_MODULE_INDEX_DESC, ParserUtil.MESSAGE_INVALID_INDEX);
+        assertParseFailure(parser, "1" + INVALID_MODULE_INDEX_DESC,
+                String.format(ParserUtil.MESSAGE_INVALID_INDEX_FOR, "Module"));
 
         // invalid isRecurring
         assertParseFailure(parser, "1" + INVALID_RECURRING_DESC, IsRecurring.MESSAGE_CONSTRAINTS);

--- a/src/test/java/seedu/address/logic/parser/meeting/EditMeetingCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/meeting/EditMeetingCommandParserTest.java
@@ -102,7 +102,7 @@ public class EditMeetingCommandParserTest {
 
         // invalid module
         assertParseFailure(parser, "1" + INVALID_MODULE_INDEX_DESC,
-                String.format(ParserUtil.MESSAGE_INVALID_INDEX_FOR, "Module"));
+                String.format("%s %s", "Module", ParserUtil.MESSAGE_INVALID_INDEX));
 
         // invalid isRecurring
         assertParseFailure(parser, "1" + INVALID_RECURRING_DESC, IsRecurring.MESSAGE_CONSTRAINTS);


### PR DESCRIPTION
## Related issues
<!-- Please link to the Github issue(s) this PR resolves (type `#` to autocomplete issue) -->
Fixes #171.
## Description
<!-- Describe your changes -->
Overloaded `ParserUtil::parseIndex` to take in an additional `indexType` argument that will indicate the type of index that was parsed should a `ParseException` be thrown.
```java
// The following will throw a ParseException with the following message:
// "Module Index is not a non-zero unsigned integer."
parseIndex("0", "Module");

// The following will throw a ParseException with the following message:
// "Index is not a non-zero unsigned integer."
parseIndex("0");

// The following will throw a ParseException with the following message:
// "Index is not a non-zero unsigned integer."
parseIndex("0", "");
```
<!-- If it affects UI, screenshots are highly recommended -->

## How to test
<!-- List down the steps to test this, if applicable -->
Start LinkyTime and enter the following command: `edit 2 m/`.

You should now see the following:
<img width="429" alt="Screenshot 2022-04-09 at 7 47 53 PM" src="https://user-images.githubusercontent.com/12640352/162572794-ebf3e4d8-42f4-402d-89c7-0d4b7c3c9862.png">